### PR TITLE
Fix animation callbacks and mount-only effect in Collapsible

### DIFF
--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -43,7 +43,11 @@ const Collapsible = ({
     wrapperRef.current?.classList.add(styles.state__animate);
   };
 
-  const handleAnimationRest = () => {
+  // Keep the onRest logic in a ref so the version captured by the initial
+  // useSpring(() => ...) call always sees the latest props (isSetHeightAuto,
+  // finalHeight, onAnimationFinished) instead of the ones from mount.
+  const animationRestRef = useRef<() => void>(() => {});
+  animationRestRef.current = () => {
     if (isExpandedRef.current && isSetHeightAuto) {
       api.start({
         height: finalHeight,
@@ -55,6 +59,8 @@ const Collapsible = ({
       onAnimationFinished();
     }
   };
+
+  const handleAnimationRest = () => animationRestRef.current();
 
   const [{ height, opacity }, api] = useSpring<TContainerHeight>(() => {
     const resultContainerHeight = containerRef.current

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -34,9 +34,27 @@ const Collapsible = ({
   onAnimationFinished,
 }: TCollapsibleProps) => {
   const isExpandedRef = useRef<boolean>(isExpanded);
+  const isMountedRef = useRef<boolean>(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const containerContentRef = useRef<HTMLDivElement | null>(null);
+
+  const handleAnimationStart = () => {
+    wrapperRef.current?.classList.add(styles.state__animate);
+  };
+
+  const handleAnimationRest = () => {
+    if (isExpandedRef.current && isSetHeightAuto) {
+      api.start({
+        height: finalHeight,
+        immediate: true,
+      });
+    }
+    wrapperRef.current?.classList.remove(styles.state__animate);
+    if (isFunction(onAnimationFinished)) {
+      onAnimationFinished();
+    }
+  };
 
   const [{ height, opacity }, api] = useSpring<TContainerHeight>(() => {
     const resultContainerHeight = containerRef.current
@@ -57,20 +75,8 @@ const Collapsible = ({
         opacity: 1,
       },
       immediate: !isAnimateHeight,
-      onStart: () => {
-        // append animate class
-        wrapperRef.current?.classList.add(styles.state__animate);
-      },
-      onRest: () => {
-        if (isExpandedRef.current && isSetHeightAuto) {
-          api.start({
-            height: finalHeight,
-            immediate: true,
-          });
-        }
-        // remove animate class
-        wrapperRef.current?.classList.remove(styles.state__animate);
-      },
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
       config: (key: string) => {
         if (key === "height") {
           return animationHeightConfig;
@@ -79,7 +85,7 @@ const Collapsible = ({
         }
       },
     };
-  }, [containerRef.current]);
+  });
 
   const collapseContainer = (isClearAccordionTab: boolean = true) => {
     const resultContainerHeight = containerRef.current
@@ -101,11 +107,8 @@ const Collapsible = ({
         opacity: isUndefined(minHeight) && isAnimateOpacity ? 0 : 1,
       },
       immediate: !isAnimateHeight,
-      onRest: () => {
-        if (isFunction(onAnimationFinished)) {
-          onAnimationFinished();
-        }
-      },
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
     });
   };
 
@@ -120,11 +123,8 @@ const Collapsible = ({
     api.start({
       height: containerContentRef.current.offsetHeight,
       opacity: 1,
-      onRest: () => {
-        if (isFunction(onAnimationFinished)) {
-          onAnimationFinished();
-        }
-      },
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
     });
   };
 
@@ -146,13 +146,15 @@ const Collapsible = ({
     }
   }, [openedTabId]);
 
-  // collapse tabs by external state change
+  // react to external isExpanded changes (skip the very first mount)
   useEffect(() => {
-    if (isUndefined(isExpandedRef.current)) {
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
       isExpandedRef.current = isExpanded;
+      return;
     }
 
-    if (!isExpanded) {
+    if (!isExpanded && isExpandedRef.current) {
       collapseContainer(!isAccordion);
     } else if (isExpanded && !isExpandedRef.current) {
       expandContainer();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,4 +35,8 @@ const App = () => {
   );
 };
 
-ReactDOM.createRoot(document.getElementById("root")!).render(<App />);
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element with id 'root' was not found");
+}
+ReactDOM.createRoot(rootElement).render(<App />);

--- a/src/types/collapsible.ts
+++ b/src/types/collapsible.ts
@@ -7,9 +7,6 @@ export type TContainerHeight = SpringValues<{
   opacity: number;
 }>;
 
-const collapsibleModesArr = ["vertical", "horizontal"] as const;
-type TCollapsibleMode = (typeof collapsibleModesArr)[number];
-
 const collapsibleStylesArr = ["wrapper", "content"] as const;
 type TCollapsibleStylesSection = (typeof collapsibleStylesArr)[number];
 
@@ -20,7 +17,6 @@ type TCollapsibleStyles = Partial<{
 interface ICollapsibleBaseProps {
   content: React.ReactNode;
   isExpanded: boolean;
-  mode?: TCollapsibleMode;
   isInitiallyExpanded?: boolean;
   setIsExpanded: Dispatch<SetStateAction<boolean>> | ((flag: boolean) => void);
   isOverflowHidden?: boolean;


### PR DESCRIPTION
## Summary

Fixes a cluster of related rendering/animation bugs in `Collapsible` and a few tidying issues.

### Why

When the user opens/closes the panel more than once, things gradually break:
- The `state__animate` class stays stuck on the wrapper after the first cycle.
- `isSetHeightAuto` stops switching the wrapper to `auto` height after the first expand → no auto-grow when content changes inside the panel.
- `onAnimationFinished` fires inconsistently (sometimes once, sometimes never, depending on which path was taken).

Root cause: each `api.start` in `collapseContainer` / `expandContainer` overwrites the `onStart` / `onRest` defined in the `useSpring` initializer, so only one of the three behaviors (class toggling, auto-height set, user callback) survives per call.

On top of that:
- The `[isExpanded]` effect calls `collapseContainer` on mount even when the panel is already collapsed (a `setIsExpanded(false)` and a redundant collapse animation on the very first render).
- The `[containerRef.current]` dep on `useSpring` is a no-op — mutating a ref doesn't trigger a re-render, so the dep array can never refresh.
- `mode?: TCollapsibleMode` is declared in the props type but never read by the component — dead API.
- Non-null assertion on `getElementById("root")` violates strict null discipline.

### Changes

- Extract `handleAnimationStart` / `handleAnimationRest` as stable handlers, pass them to **every** `api.start` (initializer + collapse + expand). Now the class is always cleared, `isSetHeightAuto` always reapplies, and `onAnimationFinished` always fires once per animation.
- Add a mount-guard ref to the `[isExpanded]` effect — first render no longer triggers `collapseContainer`. Also replaces the impossible `isUndefined(isExpandedRef.current)` branch (the ref is initialized with a `boolean`).
- Drop `[containerRef.current]` from `useSpring` deps.
- Drop unused `mode` from `TCollapsibleProps`.
- Replace non-null assertion in `src/index.tsx` with an explicit guard.

### Diff size

3 files changed, 35 insertions(+), 33 deletions(-) — minimum-invasive, no cosmetic refactor.

## Test plan

- [ ] `npm install && npm run lint` passes
- [ ] Manual: open/close the panel 3+ times — no stuck class, expand-then-resize-content still grows, `onAnimationFinished` fires every time
- [ ] Manual: render with `isExpanded={false}` initially — no flicker on mount
- [ ] `npm run build` (tsup) produces clean ESM/CJS/dts artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)