### PR TITLE
v2: playground, sandbox, animation presets, GitHub Pages

### DIFF
--- a/.github/workflows/deploy-playground.yml
+++ b/.github/workflows/deploy-playground.yml
@@ -1,0 +1,42 @@
+name: Deploy Playground to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run playground:build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./playground-dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 dist
-package-lock.json
+playground-dist
 .idea
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -1,3 +1,89 @@
-# Simple, but powerful collapse\expand React block, using react-spring as animation library
+# Collapsible
 
-[Live example](https://codesandbox.io/p/sandbox/collapsible-yvwhgj)
+A small, focused React component for collapse/expand interactions, animated by [react-spring](https://www.react-spring.dev/).
+
+🎨 **Live playground:** https://kolosochek.github.io/collapsible/
+
+## Install
+
+```bash
+npm install collapsible @react-spring/web
+```
+
+`react`, `react-dom`, and `@react-spring/web` are peer dependencies.
+
+## Usage
+
+```tsx
+import { useState } from "react";
+import { Collapsible } from "collapsible";
+
+const App = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <>
+      <button onClick={() => setIsExpanded((p) => !p)}>Toggle</button>
+      <Collapsible
+        isExpanded={isExpanded}
+        setIsExpanded={setIsExpanded}
+        content={<p>Content goes here.</p>}
+      />
+    </>
+  );
+};
+```
+
+## Animation presets
+
+The component ships three named presets that match react-spring's built-in named configs:
+
+| Preset | mass | tension | friction | Character |
+|---|---|---|---|---|
+| `gentle` (default) | 1 | 120 | 14 | Soft, no overshoot |
+| `wobbly` | 1 | 180 | 12 | Visible bounce |
+| `stiff` | 1 | 210 | 20 | Fast, crisp |
+
+```tsx
+<Collapsible animationPreset="wobbly" /* ... */ />
+```
+
+Override individual keys with `animationHeightConfig` — explicit values win per-key:
+
+```tsx
+<Collapsible
+  animationPreset="wobbly"
+  animationHeightConfig={{ tension: 300 }}  // wobbly mass + friction, custom tension
+/>
+```
+
+## Migrating from 1.x
+
+The default animation config changed in 2.0.0. v1 used `{ mass: 1, tension: 176, friction: 26 }` — close to react-spring's `default`. v2 uses the new `gentle` preset (`{ mass: 1, tension: 120, friction: 14 }`).
+
+To restore exact v1 behavior:
+
+```tsx
+<Collapsible
+  animationHeightConfig={{ mass: 1, tension: 176, friction: 26 }}
+  /* ... */
+/>
+```
+
+Also: importing the package in v1 inadvertently called `ReactDOM.createRoot` because the lib entry doubled as a demo. v2 ships an exports-only entry; this side-effect is gone.
+
+## Local development
+
+```bash
+npm install
+npm run dev          # Vite playground at http://localhost:5173/
+npm run lint         # tsc --noEmit
+npm run build        # tsup library build into dist/
+```
+
+## Deploying the playground
+
+The playground deploys to GitHub Pages automatically on push to `main` via `.github/workflows/deploy-playground.yml`. First-time setup: in the repo's **Settings → Pages**, set **Source** to **GitHub Actions**.
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](./LICENSE).

--- a/docs/superpowers/plans/2026-05-02-collapsible-examples.md
+++ b/docs/superpowers/plans/2026-05-02-collapsible-examples.md
@@ -112,17 +112,19 @@ Replace the file contents with:
   },
   "devDependencies": {
     "@react-spring/web": "^9.7.5",
-    "@types/react": "latest",
-    "@types/react-dom": "latest",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.0",
-    "react": "latest",
-    "react-dom": "latest",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "tsup": "^8.3.5",
-    "typescript": "latest",
+    "typescript": "^5.6.3",
     "vite": "^5.4.0"
   }
 }
 ```
+
+> **Note:** `typescript` is pinned to `^5.6.3` (latest TS5) instead of `latest`. TypeScript 6 introduces stricter checks (`moduleResolution: "node"` becomes a hard error, `react-jsx` transform changes children inference) that conflict with `@react-spring/web@9.7.5`'s typings. Pinning to TS5 keeps the plan working as written. React/react-dom and their types are pinned to known-good 18.x rather than `latest` for the same stability reason.
 
 - [ ] **Step 2: Update `.gitignore`**
 
@@ -154,7 +156,7 @@ Replace contents with:
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,

--- a/docs/superpowers/plans/2026-05-02-collapsible-examples.md
+++ b/docs/superpowers/plans/2026-05-02-collapsible-examples.md
@@ -1,0 +1,2560 @@
+# Collapsible Examples, Sandbox, Presets and GitHub Pages — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Vite-based playground with five static examples, an interactive sandbox with named profiles, three first-class animation presets on `<Collapsible />`, and a GitHub Pages deployment.
+
+**Architecture:** The library lives in `src/` and is built by `tsup` into `dist/`; the playground lives in `playground/` and is built by Vite. Both share `tsconfig.json`. A new `animationPreset` prop selects from three named configs (`gentle`, `wobbly`, `stiff`); explicit `animationHeightConfig` overrides per-key. GitHub Actions builds the playground on push to `main` and deploys via `actions/deploy-pages@v4`.
+
+**Tech Stack:** React 18+, TypeScript, `@react-spring/web@9.7.5`, `tsup` (library build), Vite 5 + `@vitejs/plugin-react` (playground), GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-collapsible-examples-design.md`
+
+---
+
+## Pre-flight notes
+
+- **No test runner.** The spec defers automated testing. Each task ends with deterministic verification (`tsc --noEmit`, `npm run build`) plus manual smoke checks against the playground at `http://localhost:5173`. There is no `vitest`/`jest` setup; do not add one.
+- **Branch.** Work on a feature branch off `main` (e.g., `feat/playground-and-presets`). Final merge strategy is the maintainer's choice.
+- **Commit style.** Follow existing repo style — short imperative subject, optional body. Co-Author footer included as per global instructions.
+- **Stage specifically.** Never `git add .` / `-A`. Always stage named files.
+
+---
+
+## File Structure
+
+| Path | Action | Purpose |
+|---|---|---|
+| `package.json` | modify | scripts, deps, peer-deps, version 2.0.0 |
+| `.gitignore` | modify | un-ignore `package-lock.json`, ignore `playground-dist` |
+| `tsconfig.json` | modify | `jsx: react-jsx`, include playground |
+| `tsconfig.lib.json` | create | tsup-only TS config |
+| `tsup.config.ts` | create | library build config |
+| `vite.config.ts` | create | Vite config with `base: /collapsible/` |
+| `src/index.tsx` | rewrite | exports only — no React render |
+| `src/components/Collapsible/presets.ts` | create | `PRESETS`, `TAnimationPreset` |
+| `src/components/Collapsible/Collapsible.tsx` | modify | wire `animationPreset` prop |
+| `src/types/collapsible.ts` | modify | add `animationPreset` to props type |
+| `playground/index.html` | create | Vite entry HTML |
+| `playground/main.tsx` | create | React root mount |
+| `playground/App.tsx` | create | layout + nav state |
+| `playground/styles/global.css` | create | base styles |
+| `playground/nav/Sidebar.tsx` | create | view switcher |
+| `playground/examples/shared/ExamplePage.tsx` | create | layout wrapper |
+| `playground/examples/shared/ConfigCard.tsx` | create | toggleable card with config label |
+| `playground/examples/shared/content.ts` | create | lorem snippets |
+| `playground/examples/PresetsExample.tsx` | create | preset showcase |
+| `playground/examples/MassSpectrumExample.tsx` | create | mass spectrum |
+| `playground/examples/TensionSpectrumExample.tsx` | create | tension spectrum |
+| `playground/examples/FrictionSpectrumExample.tsx` | create | friction spectrum |
+| `playground/examples/AccordionExample.tsx` | create | FAQ accordion |
+| `playground/examples/registry.ts` | create | view → component mapping |
+| `playground/sandbox/types.ts` | create | `TSandboxConfig`, `TProfilesStore` |
+| `playground/sandbox/controls/Slider.tsx` | create | range input primitive |
+| `playground/sandbox/controls/Toggle.tsx` | create | checkbox primitive |
+| `playground/sandbox/controls/Select.tsx` | create | select primitive |
+| `playground/sandbox/useProfiles.ts` | create | localStorage hook |
+| `playground/sandbox/ControlsPanel.tsx` | create | all controls |
+| `playground/sandbox/ProfilesPanel.tsx` | create | save/load/delete UI |
+| `playground/sandbox/Sandbox.tsx` | create | composite |
+| `playground/sandbox/styles.module.css` | create | sandbox layout |
+| `.github/workflows/deploy-playground.yml` | create | CI deploy |
+| `README.md` | rewrite | docs + migration + playground link |
+| `public/index.html` | delete | replaced by `playground/index.html` |
+
+---
+
+## Task 1: Tooling overhaul (package.json, tsconfigs, tsup config)
+
+**Files:**
+- Modify: `package.json`
+- Modify: `.gitignore`
+- Modify: `tsconfig.json`
+- Create: `tsconfig.lib.json`
+- Create: `tsup.config.ts`
+
+- [ ] **Step 1: Rewrite `package.json`**
+
+Replace the file contents with:
+
+```jsonc
+{
+  "name": "collapsible",
+  "version": "2.0.0",
+  "description": "Collapse\\expand block for any react applications",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "scripts": {
+    "dev": "vite",
+    "lint": "tsc --noEmit",
+    "build": "tsup --config tsup.config.ts",
+    "playground:build": "vite build",
+    "playground:preview": "vite preview"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kolosochek/collapsible.git#main"
+  },
+  "keywords": ["react", "react-spring", "collapse", "expand", "animation"],
+  "author": "Dmitriy Kolosovskiy",
+  "license": "GPL-3.0-or-later",
+  "bugs": {
+    "url": "https://github.com/kolosochek/collapsible/issues"
+  },
+  "homepage": "https://github.com/kolosochek/collapsible/tree/main#readme",
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18",
+    "@react-spring/web": "^9.7.5"
+  },
+  "devDependencies": {
+    "@react-spring/web": "^9.7.5",
+    "@types/react": "latest",
+    "@types/react-dom": "latest",
+    "@vitejs/plugin-react": "^4.3.0",
+    "react": "latest",
+    "react-dom": "latest",
+    "tsup": "^8.3.5",
+    "typescript": "latest",
+    "vite": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step 2: Update `.gitignore`**
+
+Replace contents with:
+
+```
+node_modules
+dist
+playground-dist
+.idea
+.DS_Store
+```
+
+(Removed `package-lock.json` so the lockfile is committed for reproducible CI builds. Added `playground-dist`.)
+
+- [ ] **Step 3: Update `tsconfig.json`**
+
+Replace contents with:
+
+```jsonc
+{
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src", "playground"]
+}
+```
+
+- [ ] **Step 4: Create `tsconfig.lib.json`**
+
+```jsonc
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["playground"]
+}
+```
+
+- [ ] **Step 5: Create `tsup.config.ts`**
+
+```ts
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.tsx"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  external: ["react", "react-dom", "@react-spring/web"],
+  tsconfig: "tsconfig.lib.json",
+});
+```
+
+- [ ] **Step 6: Install dependencies**
+
+Run: `npm install`
+Expected: completes without errors. `package-lock.json` is generated.
+
+- [ ] **Step 7: Verify type-check still passes**
+
+Run: `npm run lint`
+Expected: no TypeScript errors. Note that `src/index.tsx` still contains the React render at this point — that's fine for tsc, it's removed in Task 4.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add package.json package-lock.json .gitignore tsconfig.json tsconfig.lib.json tsup.config.ts
+git commit -m "$(cat <<'EOF'
+Configure Vite + tsup tooling and bump deps
+
+- Move react/react-dom/@react-spring/web from deps to peerDeps
+- Add Vite + plugin-react devDeps
+- Add tsup.config.ts and tsconfig.lib.json (library-only build)
+- Bump version 1.0.0 -> 2.0.0
+- Commit package-lock.json for reproducible CI
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Vite + minimal playground bootstrap
+
+**Files:**
+- Create: `vite.config.ts`
+- Create: `playground/index.html`
+- Create: `playground/main.tsx`
+- Create: `playground/App.tsx` (placeholder)
+- Create: `playground/styles/global.css`
+- Delete: `public/index.html`
+
+- [ ] **Step 1: Create `vite.config.ts`**
+
+```ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  root: "playground",
+  base: "/collapsible/",
+  build: {
+    outDir: "../playground-dist",
+    emptyOutDir: true,
+  },
+  server: { port: 5173, open: true },
+});
+```
+
+- [ ] **Step 2: Create `playground/index.html`**
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collapsible — Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>
+```
+
+- [ ] **Step 3: Create `playground/main.tsx`**
+
+```tsx
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles/global.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element with id 'root' was not found");
+}
+createRoot(rootElement).render(<App />);
+```
+
+- [ ] **Step 4: Create `playground/styles/global.css`**
+
+```css
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  color: #1a1a1a;
+  background: #fafafa;
+}
+
+a {
+  color: #0a66c2;
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+p {
+  line-height: 1.55;
+}
+```
+
+- [ ] **Step 5: Create `playground/App.tsx` (placeholder)**
+
+```tsx
+const App = () => {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Collapsible — Playground</h1>
+      <p>Bootstrap OK. Sidebar and content come in Task 5.</p>
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 6: Delete `public/index.html`**
+
+Run: `rm public/index.html && rmdir public`
+Expected: `public/` directory removed.
+
+- [ ] **Step 7: Run dev server and verify**
+
+Run: `npm run dev`
+Expected: browser opens at `http://localhost:5173/` and shows "Collapsible — Playground / Bootstrap OK." Stop the dev server with Ctrl+C.
+
+- [ ] **Step 8: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add vite.config.ts playground/
+git rm public/index.html
+git commit -m "$(cat <<'EOF'
+Bootstrap Vite playground with placeholder App
+
+- vite.config.ts with base /collapsible/ and root playground/
+- playground/index.html, main.tsx, App.tsx placeholder
+- Global stylesheet (typography + reset)
+- Remove obsolete public/index.html
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Library — animation presets file
+
+**Files:**
+- Create: `src/components/Collapsible/presets.ts`
+
+- [ ] **Step 1: Create the presets file**
+
+```ts
+import { SpringConfig } from "@react-spring/web";
+
+export const PRESETS = {
+  gentle: { mass: 1, tension: 120, friction: 14 },
+  wobbly: { mass: 1, tension: 180, friction: 12 },
+  stiff: { mass: 1, tension: 210, friction: 20 },
+} as const satisfies Record<string, SpringConfig>;
+
+export type TAnimationPreset = keyof typeof PRESETS;
+```
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Collapsible/presets.ts
+git commit -m "$(cat <<'EOF'
+Add animation presets module
+
+Three named SpringConfigs (gentle/wobbly/stiff) matching react-spring's
+built-in named configs. Used by the new animationPreset prop.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Library — wire `animationPreset` prop into Collapsible
+
+**Files:**
+- Modify: `src/types/collapsible.ts`
+- Modify: `src/components/Collapsible/Collapsible.tsx`
+- Modify: `src/index.tsx`
+
+- [ ] **Step 1: Add `animationPreset` to props type**
+
+In `src/types/collapsible.ts`, add the import at the top and the new prop in `ICollapsibleBaseProps`:
+
+```ts
+import React, { Dispatch, SetStateAction } from "react";
+import { SpringConfig, SpringValues } from "@react-spring/web";
+import { TAnimationPreset } from "../components/Collapsible/presets";
+
+export type TContainerHeight = SpringValues<{
+  height: number | string;
+  maxWidth: number | string;
+  opacity: number;
+}>;
+
+const collapsibleStylesArr = ["wrapper", "content"] as const;
+type TCollapsibleStylesSection = (typeof collapsibleStylesArr)[number];
+
+type TCollapsibleStyles = Partial<{
+  [key in TCollapsibleStylesSection]: React.CSSProperties;
+}>;
+
+interface ICollapsibleBaseProps {
+  content: React.ReactNode;
+  isExpanded: boolean;
+  isInitiallyExpanded?: boolean;
+  setIsExpanded: Dispatch<SetStateAction<boolean>> | ((flag: boolean) => void);
+  isOverflowHidden?: boolean;
+  isAnimateOpacity?: boolean;
+  isAnimateHeight?: boolean;
+  isSetHeightAuto?: boolean;
+  isContentSelectable?: boolean;
+  animationPreset?: TAnimationPreset;
+  animationHeightConfig?: SpringConfig;
+  animationOpacityConfig?: SpringConfig;
+  customStyles?: TCollapsibleStyles;
+  minHeight?: number | string;
+  onAnimationFinished?: () => void;
+  wrapperClassName?: string;
+  finalHeight?: string;
+}
+
+interface ICollapsibleAccordionNeverProps {
+  isAccordion?: never;
+  accordionTabId?: never;
+  openedTabId?: never;
+  setOpenedTabId?: never;
+}
+
+interface ICollapsibleAccordionProps {
+  isAccordion: boolean;
+  accordionTabId: string;
+  openedTabId: string;
+  setOpenedTabId: Dispatch<SetStateAction<string>>;
+}
+
+export type TCollapsibleProps = ICollapsibleBaseProps &
+  (ICollapsibleAccordionProps | ICollapsibleAccordionNeverProps);
+```
+
+- [ ] **Step 2: Update `Collapsible.tsx` — destructure and resolve config**
+
+In `src/components/Collapsible/Collapsible.tsx`, change the destructure block and add the resolution. The full updated file:
+
+```tsx
+import React from "react";
+import { useEffect, useRef } from "react";
+import { animated, useSpring, SpringConfig } from "@react-spring/web";
+import styles from "./styles.module.css";
+import { PRESETS } from "./presets";
+import { TCollapsibleProps, TContainerHeight } from "../../types/collapsible";
+import { isFunction, isUndefined } from "../../types/typeguards";
+
+const Collapsible = ({
+  content,
+  isExpanded,
+  setIsExpanded,
+  isOverflowHidden = true,
+  isAnimateOpacity = true,
+  isAnimateHeight = true,
+  isSetHeightAuto = true,
+  isAccordion = false,
+  isContentSelectable = true,
+  minHeight,
+  animationPreset = "gentle",
+  animationHeightConfig,
+  animationOpacityConfig = {
+    duration: 250,
+  },
+  wrapperClassName = "",
+  customStyles,
+  accordionTabId,
+  openedTabId,
+  setOpenedTabId,
+  finalHeight = "auto",
+  onAnimationFinished,
+}: TCollapsibleProps) => {
+  const isExpandedRef = useRef<boolean>(isExpanded);
+  const isMountedRef = useRef<boolean>(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const containerContentRef = useRef<HTMLDivElement | null>(null);
+
+  const resolvedHeightConfig: SpringConfig = {
+    ...PRESETS[animationPreset],
+    ...animationHeightConfig,
+  };
+
+  const handleAnimationStart = () => {
+    wrapperRef.current?.classList.add(styles.state__animate);
+  };
+
+  const animationRestRef = useRef<() => void>(() => {});
+  animationRestRef.current = () => {
+    if (isExpandedRef.current && isSetHeightAuto) {
+      api.start({
+        height: finalHeight,
+        immediate: true,
+      });
+    }
+    wrapperRef.current?.classList.remove(styles.state__animate);
+    if (isFunction(onAnimationFinished)) {
+      onAnimationFinished();
+    }
+  };
+
+  const handleAnimationRest = () => animationRestRef.current();
+
+  const [{ height, opacity }, api] = useSpring<TContainerHeight>(() => {
+    const resultContainerHeight = containerRef.current
+      ? containerRef.current?.offsetHeight
+      : 0;
+
+    return {
+      from: {
+        height: isExpandedRef.current
+          ? finalHeight
+          : isAnimateHeight
+          ? minHeight ?? 0
+          : finalHeight,
+        opacity: isUndefined(minHeight) && isAnimateOpacity ? 0 : 1,
+      },
+      to: {
+        height: isExpandedRef.current ? finalHeight : resultContainerHeight,
+        opacity: 1,
+      },
+      immediate: !isAnimateHeight,
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
+      config: (key: string) => {
+        if (key === "height") {
+          return resolvedHeightConfig;
+        } else if (key === "opacity" && isAnimateOpacity) {
+          return animationOpacityConfig;
+        }
+      },
+    };
+  });
+
+  const collapseContainer = (isClearAccordionTab: boolean = true) => {
+    const resultContainerHeight = containerRef.current
+      ? containerRef.current?.offsetHeight
+      : 0;
+
+    isExpandedRef.current = false;
+    setIsExpanded(false);
+    if (isFunction(setOpenedTabId) && isClearAccordionTab) {
+      setOpenedTabId("");
+    }
+    api.start({
+      from: {
+        height: resultContainerHeight,
+        opacity: 1,
+      },
+      to: {
+        height: minHeight ?? 0,
+        opacity: isUndefined(minHeight) && isAnimateOpacity ? 0 : 1,
+      },
+      immediate: !isAnimateHeight,
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
+    });
+  };
+
+  const expandContainer = () => {
+    if (!containerContentRef.current) return;
+
+    isExpandedRef.current = true;
+    setIsExpanded(true);
+    if (isFunction(setOpenedTabId) && accordionTabId) {
+      setOpenedTabId(accordionTabId);
+    }
+    api.start({
+      height: containerContentRef.current.offsetHeight,
+      opacity: 1,
+      onStart: handleAnimationStart,
+      onRest: handleAnimationRest,
+    });
+  };
+
+  const handleStopPropagation = (
+    ev: MouseEvent | React.MouseEvent | React.TouchEvent
+  ) => {
+    ev.stopPropagation();
+  };
+
+  const containerStyle = {
+    opacity: isAnimateOpacity ? opacity : 1,
+    height: height,
+  };
+
+  useEffect(() => {
+    if (isAccordion && openedTabId !== accordionTabId) {
+      collapseContainer(false);
+    }
+  }, [openedTabId]);
+
+  useEffect(() => {
+    if (!isMountedRef.current) {
+      isMountedRef.current = true;
+      isExpandedRef.current = isExpanded;
+      return;
+    }
+
+    if (!isExpanded && isExpandedRef.current) {
+      collapseContainer(!isAccordion);
+    } else if (isExpanded && !isExpandedRef.current) {
+      expandContainer();
+    }
+  }, [isExpanded]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`${styles.wrapper}${
+        wrapperClassName ? ` ${wrapperClassName}` : ""
+      }${!isContentSelectable ? ` ${styles.state__unselectable}` : ""}${
+        isOverflowHidden ? ` ${styles.state__overflow_hidden}` : ""
+      }`}
+      style={customStyles?.wrapper}
+    >
+      <animated.div
+        ref={containerRef}
+        style={containerStyle}
+        onClick={handleStopPropagation}
+        className={styles.content_wrapper}
+      >
+        <div ref={containerContentRef} style={customStyles?.content}>
+          {content}
+        </div>
+      </animated.div>
+    </div>
+  );
+};
+
+export default Collapsible;
+```
+
+Key changes vs. v1:
+- `animationPreset = "gentle"` default added.
+- `animationHeightConfig` no longer has a literal default (was `{ mass: 1, tension: 176, friction: 26 }`).
+- `resolvedHeightConfig = { ...PRESETS[animationPreset], ...animationHeightConfig }` computed once per render.
+- `useSpring` config callback for `"height"` returns `resolvedHeightConfig`.
+
+- [ ] **Step 3: Replace `src/index.tsx` with library exports only**
+
+```tsx
+export { default as Collapsible } from "./components/Collapsible/Collapsible";
+export { PRESETS } from "./components/Collapsible/presets";
+export type { TAnimationPreset } from "./components/Collapsible/presets";
+export type { TCollapsibleProps } from "./types/collapsible";
+```
+
+- [ ] **Step 4: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 5: Run library build**
+
+Run: `npm run build`
+Expected: `dist/index.js`, `dist/index.mjs`, `dist/index.d.ts` are created. Inspect `dist/index.mjs` to confirm no `createRoot` calls — only exports.
+
+Run: `grep -c "createRoot" dist/index.mjs || echo "0 matches"`
+Expected: `0 matches`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/collapsible.ts src/components/Collapsible/Collapsible.tsx src/index.tsx
+git commit -m "$(cat <<'EOF'
+Add animationPreset prop and clean library entry
+
+- New animationPreset prop (gentle|wobbly|stiff), default "gentle"
+- Explicit animationHeightConfig overrides preset per-key
+- Clean src/index.tsx to exports-only (fixes v1 bug where
+  importing the package executed ReactDOM.createRoot)
+
+BREAKING CHANGE: default animation config changes from
+{tension:176, friction:26} to gentle {tension:120, friction:14}.
+Pass animationHeightConfig={{mass:1,tension:176,friction:26}} to
+restore v1 behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Sidebar nav + App layout
+
+**Files:**
+- Create: `playground/nav/Sidebar.tsx`
+- Modify: `playground/App.tsx`
+- Modify: `playground/styles/global.css` (add layout classes)
+
+- [ ] **Step 1: Add layout styles to `playground/styles/global.css`**
+
+Append to the existing file:
+
+```css
+.app__layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.app__sidebar {
+  background: #fff;
+  border-right: 1px solid #e5e5e5;
+  padding: 24px 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.app__sidebar h2 {
+  margin: 0 24px 16px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b6b6b;
+}
+
+.app__nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app__nav-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 10px 24px;
+  font: inherit;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.app__nav-item:hover {
+  background: #f1f1f1;
+}
+
+.app__nav-item--active {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.app__main {
+  padding: 32px 40px 80px;
+  max-width: 960px;
+  width: 100%;
+}
+```
+
+- [ ] **Step 2: Create `playground/nav/Sidebar.tsx`**
+
+```tsx
+import "../styles/global.css";
+
+export type TView =
+  | "presets"
+  | "mass"
+  | "tension"
+  | "friction"
+  | "accordion"
+  | "sandbox";
+
+const NAV_ITEMS: Array<{ id: TView; label: string; group: "examples" | "interactive" }> = [
+  { id: "presets", label: "1. Presets", group: "examples" },
+  { id: "mass", label: "2. Mass spectrum", group: "examples" },
+  { id: "tension", label: "3. Tension spectrum", group: "examples" },
+  { id: "friction", label: "4. Friction spectrum", group: "examples" },
+  { id: "accordion", label: "5. FAQ accordion", group: "examples" },
+  { id: "sandbox", label: "Sandbox", group: "interactive" },
+];
+
+type Props = {
+  active: TView;
+  onChange: (view: TView) => void;
+};
+
+const Sidebar = ({ active, onChange }: Props) => {
+  const examples = NAV_ITEMS.filter((i) => i.group === "examples");
+  const interactive = NAV_ITEMS.filter((i) => i.group === "interactive");
+
+  return (
+    <aside className="app__sidebar">
+      <h2>Examples</h2>
+      <ul className="app__nav-list">
+        {examples.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={`app__nav-item${
+                active === item.id ? " app__nav-item--active" : ""
+              }`}
+              onClick={() => onChange(item.id)}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 24 }}>Interactive</h2>
+      <ul className="app__nav-list">
+        {interactive.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={`app__nav-item${
+                active === item.id ? " app__nav-item--active" : ""
+              }`}
+              onClick={() => onChange(item.id)}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default Sidebar;
+```
+
+- [ ] **Step 3: Update `playground/App.tsx`**
+
+Replace the placeholder with:
+
+```tsx
+import { useState } from "react";
+import Sidebar, { TView } from "./nav/Sidebar";
+
+const App = () => {
+  const [view, setView] = useState<TView>("presets");
+
+  return (
+    <div className="app__layout">
+      <Sidebar active={view} onChange={setView} />
+      <main className="app__main">
+        <h1>{view}</h1>
+        <p>View "{view}" — content arrives in later tasks.</p>
+      </main>
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 4: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 5: Manual verify**
+
+Run: `npm run dev` (in another terminal). At `http://localhost:5173/`:
+- Sidebar shows two groups (Examples / Interactive) with six clickable items.
+- Clicking a sidebar item swaps the heading in the main area.
+- Active item is visually highlighted.
+
+Stop with Ctrl+C.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add playground/nav/Sidebar.tsx playground/App.tsx playground/styles/global.css
+git commit -m "$(cat <<'EOF'
+Add sidebar nav and view switching in playground
+
+- TView union for the six available views
+- Sidebar groups examples + interactive sections
+- App.tsx wires useState<TView> to Sidebar.onChange
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Shared example primitives (content + ExamplePage + ConfigCard)
+
+**Files:**
+- Create: `playground/examples/shared/content.ts`
+- Create: `playground/examples/shared/ExamplePage.tsx`
+- Create: `playground/examples/shared/ConfigCard.tsx`
+- Create: `playground/examples/shared/styles.module.css`
+
+- [ ] **Step 1: Create `playground/examples/shared/content.ts`**
+
+```ts
+export type TContentLength = "short" | "medium" | "long";
+
+const SNIPPETS: Record<TContentLength, string> = {
+  short:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur.",
+  medium:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur. " +
+    "Phasellus pellentesque, lectus id sodales pretium, lacus tortor convallis nibh, eu venenatis arcu eros vitae nibh. " +
+    "Donec vitae diam et nibh sagittis suscipit a non quam. Aliquam erat volutpat.",
+  long:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur. " +
+    "Phasellus pellentesque, lectus id sodales pretium, lacus tortor convallis nibh, eu venenatis arcu eros vitae nibh. " +
+    "Donec vitae diam et nibh sagittis suscipit a non quam. Aliquam erat volutpat. " +
+    "Sed ac libero in mauris pulvinar consequat. Suspendisse potenti. Nullam non purus a magna ullamcorper sodales. " +
+    "Mauris pellentesque, sapien id rutrum euismod, eros lectus dictum erat, et tincidunt erat justo nec lacus. " +
+    "Cras vitae nisl id risus aliquam pharetra. Etiam sit amet pretium tellus, in tristique tortor.",
+};
+
+export const getContent = (length: TContentLength = "medium"): string =>
+  SNIPPETS[length];
+```
+
+- [ ] **Step 2: Create `playground/examples/shared/styles.module.css`**
+
+```css
+.lead {
+  margin: 0 0 24px;
+  color: #4a4a4a;
+  font-size: 0.95rem;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid_3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid_4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.grid_1 {
+  grid-template-columns: 1fr;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.toolbar button {
+  padding: 8px 14px;
+  border: 1px solid #d4d4d4;
+  background: #fff;
+  border-radius: 6px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  background: #f3f3f3;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.card_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.85rem;
+  background: #f7f7f7;
+  cursor: pointer;
+  user-select: none;
+}
+
+.card_header span:last-child {
+  color: #6b6b6b;
+}
+
+.card_content {
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: #333;
+}
+```
+
+- [ ] **Step 3: Create `playground/examples/shared/ExamplePage.tsx`**
+
+```tsx
+import styles from "./styles.module.css";
+
+type Props = {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+};
+
+const ExamplePage = ({ title, description, children }: Props) => (
+  <section>
+    <h1>{title}</h1>
+    <p className={styles.lead}>{description}</p>
+    {children}
+  </section>
+);
+
+export default ExamplePage;
+```
+
+- [ ] **Step 4: Create `playground/examples/shared/ConfigCard.tsx`**
+
+```tsx
+import { useState, useEffect } from "react";
+import { SpringConfig } from "@react-spring/web";
+import { Collapsible, TAnimationPreset } from "../../../src";
+import { getContent, TContentLength } from "./content";
+import styles from "./styles.module.css";
+
+export type TSyncCommand = { isOpen: boolean; key: number };
+
+type Props = {
+  label: string;
+  preset?: TAnimationPreset;
+  config?: SpringConfig;
+  contentLength?: TContentLength;
+  syncCommand?: TSyncCommand;
+};
+
+const ConfigCard = ({
+  label,
+  preset,
+  config,
+  contentLength = "medium",
+  syncCommand,
+}: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (syncCommand) setIsExpanded(syncCommand.isOpen);
+  }, [syncCommand]);
+
+  return (
+    <article className={styles.card}>
+      <header
+        className={styles.card_header}
+        onClick={() => setIsExpanded((p) => !p)}
+      >
+        <span>{label}</span>
+        <span>{isExpanded ? "▲" : "▼"}</span>
+      </header>
+      <Collapsible
+        isExpanded={isExpanded}
+        setIsExpanded={setIsExpanded}
+        animationPreset={preset}
+        animationHeightConfig={config}
+        content={<div className={styles.card_content}>{getContent(contentLength)}</div>}
+      />
+    </article>
+  );
+};
+
+export default ConfigCard;
+```
+
+The `syncCommand` carries a unique `key` per click, so React's identity check sees a new object each time and the effect re-fires even when `isOpen` repeats.
+
+- [ ] **Step 5: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add playground/examples/shared/
+git commit -m "$(cat <<'EOF'
+Add shared example primitives
+
+- content.ts: lorem snippets in 3 lengths
+- ExamplePage: title + lead + children wrapper
+- ConfigCard: clickable header toggling a Collapsible
+- syncedExpanded prop allows a parent to fire all cards together
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Five example pages
+
+**Files:**
+- Create: `playground/examples/PresetsExample.tsx`
+- Create: `playground/examples/MassSpectrumExample.tsx`
+- Create: `playground/examples/TensionSpectrumExample.tsx`
+- Create: `playground/examples/FrictionSpectrumExample.tsx`
+- Create: `playground/examples/AccordionExample.tsx`
+- Create: `playground/examples/registry.ts`
+- Modify: `playground/App.tsx` (use registry)
+
+- [ ] **Step 1: Create `playground/examples/PresetsExample.tsx`**
+
+```tsx
+import { useRef, useState } from "react";
+import { TAnimationPreset } from "../../src";
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard, { TSyncCommand } from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const PRESETS_LIST: TAnimationPreset[] = ["gentle", "wobbly", "stiff"];
+
+const PresetsExample = () => {
+  const tickRef = useRef(0);
+  const [syncCommand, setSyncCommand] = useState<TSyncCommand | undefined>(undefined);
+
+  const fire = (isOpen: boolean) => {
+    tickRef.current += 1;
+    setSyncCommand({ isOpen, key: tickRef.current });
+  };
+
+  return (
+    <ExamplePage
+      title="1. Presets — gentle / wobbly / stiff"
+      description="Three named presets. Click each card individually, or use Open all / Close all to fire them simultaneously and compare the easing characters side by side."
+    >
+      <div className={styles.toolbar}>
+        <button type="button" onClick={() => fire(true)}>
+          Open all
+        </button>
+        <button type="button" onClick={() => fire(false)}>
+          Close all
+        </button>
+      </div>
+      <div className={`${styles.grid} ${styles.grid_3}`}>
+        {PRESETS_LIST.map((preset) => (
+          <ConfigCard
+            key={preset}
+            label={`animationPreset="${preset}"`}
+            preset={preset}
+            syncCommand={syncCommand}
+          />
+        ))}
+      </div>
+    </ExamplePage>
+  );
+};
+
+export default PresetsExample;
+```
+
+- [ ] **Step 2: Create `playground/examples/MassSpectrumExample.tsx`**
+
+```tsx
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const MASS_VALUES = [0.5, 1, 2, 5];
+
+const MassSpectrumExample = () => (
+  <ExamplePage
+    title="2. Mass spectrum"
+    description="Increasing mass at fixed tension (180) and friction (18). Higher mass feels heavier and slower to start; lower mass feels light and snappy."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {MASS_VALUES.map((mass) => (
+        <ConfigCard
+          key={mass}
+          label={`mass: ${mass}`}
+          config={{ mass, tension: 180, friction: 18 }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default MassSpectrumExample;
+```
+
+- [ ] **Step 3: Create `playground/examples/TensionSpectrumExample.tsx`**
+
+```tsx
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const TENSION_VALUES = [80, 150, 220, 400];
+
+const TensionSpectrumExample = () => (
+  <ExamplePage
+    title="3. Tension spectrum"
+    description="Increasing tension at fixed mass (1) and friction (18). Higher tension means a stiffer spring — faster acceleration, sharper finish."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {TENSION_VALUES.map((tension) => (
+        <ConfigCard
+          key={tension}
+          label={`tension: ${tension}`}
+          config={{ mass: 1, tension, friction: 18 }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default TensionSpectrumExample;
+```
+
+- [ ] **Step 4: Create `playground/examples/FrictionSpectrumExample.tsx`**
+
+```tsx
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const FRICTION_VALUES = [8, 16, 26, 60];
+
+const FrictionSpectrumExample = () => (
+  <ExamplePage
+    title="4. Friction spectrum"
+    description="Increasing friction at fixed mass (1) and tension (180). Lower friction lets the spring overshoot and bounce; higher friction critically damps it."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {FRICTION_VALUES.map((friction) => (
+        <ConfigCard
+          key={friction}
+          label={`friction: ${friction}`}
+          config={{ mass: 1, tension: 180, friction }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default FrictionSpectrumExample;
+```
+
+- [ ] **Step 5: Create `playground/examples/AccordionExample.tsx`**
+
+```tsx
+import { useState } from "react";
+import { Collapsible } from "../../src";
+import ExamplePage from "./shared/ExamplePage";
+import styles from "./shared/styles.module.css";
+
+const FAQ = [
+  {
+    id: "what",
+    question: "What is this library?",
+    answer:
+      "A small React component for collapse/expand interactions, animated by react-spring. " +
+      "It exposes a controlled isExpanded prop and a rich set of animation knobs.",
+  },
+  {
+    id: "physics",
+    question: "How does the animation work?",
+    answer:
+      "The component uses a react-spring useSpring hook to animate height and opacity. " +
+      "The height spring config is selected from a preset (gentle, wobbly, stiff) and can be " +
+      "overridden per-key via animationHeightConfig.",
+  },
+  {
+    id: "accordion",
+    question: "Can I use this as an accordion?",
+    answer:
+      "Yes — pass isAccordion=true and a shared openedTabId state. When one tab opens, " +
+      "the others collapse automatically.",
+  },
+];
+
+const AccordionExample = () => {
+  const [openedTabId, setOpenedTabId] = useState("");
+  const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
+
+  const setIsExpandedFor = (id: string) => (flag: boolean) => {
+    setExpandedMap((prev) => ({ ...prev, [id]: flag }));
+  };
+
+  return (
+    <ExamplePage
+      title="5. FAQ Accordion"
+      description="A real-world use of isAccordion=true with the wobbly preset. Opening one tab collapses the others."
+    >
+      <div className={`${styles.grid} ${styles.grid_1}`}>
+        {FAQ.map((item) => (
+          <article key={item.id} className={styles.card}>
+            <header
+              className={styles.card_header}
+              onClick={() => setIsExpandedFor(item.id)(!expandedMap[item.id])}
+            >
+              <span>{item.question}</span>
+              <span>{expandedMap[item.id] ? "▲" : "▼"}</span>
+            </header>
+            <Collapsible
+              isExpanded={!!expandedMap[item.id]}
+              setIsExpanded={setIsExpandedFor(item.id)}
+              isAccordion
+              accordionTabId={item.id}
+              openedTabId={openedTabId}
+              setOpenedTabId={setOpenedTabId}
+              animationPreset="wobbly"
+              content={<div className={styles.card_content}>{item.answer}</div>}
+            />
+          </article>
+        ))}
+      </div>
+    </ExamplePage>
+  );
+};
+
+export default AccordionExample;
+```
+
+- [ ] **Step 6: Create `playground/examples/registry.ts`**
+
+```ts
+import { ComponentType } from "react";
+import { TView } from "../nav/Sidebar";
+import PresetsExample from "./PresetsExample";
+import MassSpectrumExample from "./MassSpectrumExample";
+import TensionSpectrumExample from "./TensionSpectrumExample";
+import FrictionSpectrumExample from "./FrictionSpectrumExample";
+import AccordionExample from "./AccordionExample";
+
+export const REGISTRY: Record<Exclude<TView, "sandbox">, ComponentType> = {
+  presets: PresetsExample,
+  mass: MassSpectrumExample,
+  tension: TensionSpectrumExample,
+  friction: FrictionSpectrumExample,
+  accordion: AccordionExample,
+};
+```
+
+- [ ] **Step 7: Update `playground/App.tsx` to use registry**
+
+```tsx
+import { useState } from "react";
+import Sidebar, { TView } from "./nav/Sidebar";
+import { REGISTRY } from "./examples/registry";
+
+const App = () => {
+  const [view, setView] = useState<TView>("presets");
+
+  if (view === "sandbox") {
+    return (
+      <div className="app__layout">
+        <Sidebar active={view} onChange={setView} />
+        <main className="app__main">
+          <h1>Sandbox</h1>
+          <p>Sandbox arrives in Tasks 8–12.</p>
+        </main>
+      </div>
+    );
+  }
+
+  const ActiveView = REGISTRY[view];
+
+  return (
+    <div className="app__layout">
+      <Sidebar active={view} onChange={setView} />
+      <main className="app__main">
+        <ActiveView />
+      </main>
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 8: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 9: Manual verify all five examples**
+
+Run: `npm run dev`. At `http://localhost:5173/`:
+- "1. Presets": three cards labeled gentle/wobbly/stiff. "Open all" expands them simultaneously — visibly different animation characters (gentle smoother, wobbly bounces, stiff faster).
+- "2. Mass spectrum": four cards (0.5/1/2/5). Higher mass = slower start.
+- "3. Tension spectrum": four cards (80/150/220/400). Higher tension = quicker.
+- "4. Friction spectrum": four cards (8/16/26/60). Friction 8 visibly bounces; friction 60 is critically damped.
+- "5. FAQ Accordion": three FAQ items; clicking a closed tab opens it and closes any other open tab.
+
+Stop with Ctrl+C.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add playground/examples/ playground/App.tsx
+git commit -m "$(cat <<'EOF'
+Add five example pages and registry
+
+- PresetsExample with Open all / Close all toolbar
+- Mass / Tension / Friction spectrum examples
+- FAQ AccordionExample using isAccordion + wobbly preset
+- registry.ts maps view ids to components
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Sandbox types + control primitives
+
+**Files:**
+- Create: `playground/sandbox/types.ts`
+- Create: `playground/sandbox/controls/Slider.tsx`
+- Create: `playground/sandbox/controls/Toggle.tsx`
+- Create: `playground/sandbox/controls/Select.tsx`
+- Create: `playground/sandbox/styles.module.css`
+
+- [ ] **Step 1: Create `playground/sandbox/types.ts`**
+
+```ts
+import { TAnimationPreset } from "../../src";
+
+export type TSandboxConfig = {
+  preset: TAnimationPreset;
+  heightConfig: { mass: number; tension: number; friction: number };
+  opacityDuration: number;
+  isAnimateOpacity: boolean;
+  isAnimateHeight: boolean;
+  isOverflowHidden: boolean;
+  isContentSelectable: boolean;
+  minHeight: number;
+};
+
+export type TProfilesStore = {
+  schemaVersion: 1;
+  profiles: Record<string, TSandboxConfig>;
+};
+
+export const INITIAL_CONFIG: TSandboxConfig = {
+  preset: "gentle",
+  heightConfig: { mass: 1, tension: 180, friction: 18 },
+  opacityDuration: 250,
+  isAnimateOpacity: true,
+  isAnimateHeight: true,
+  isOverflowHidden: true,
+  isContentSelectable: true,
+  minHeight: 0,
+};
+```
+
+- [ ] **Step 2: Create `playground/sandbox/styles.module.css`**
+
+```css
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.panel_title {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b6b6b;
+}
+
+.control_row {
+  display: grid;
+  grid-template-columns: 110px 1fr 60px;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 0;
+}
+
+.control_row label {
+  font-size: 0.85rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.control_row input[type="range"] {
+  width: 100%;
+}
+
+.control_row .value {
+  font-size: 0.85rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  text-align: right;
+  color: #444;
+}
+
+.toggle_row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: 0.85rem;
+}
+
+.select_row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 12px;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.select_row select {
+  padding: 6px 8px;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  font: inherit;
+}
+
+.profiles_list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile_item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 8px;
+  background: #f7f7f7;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.profile_item button {
+  padding: 4px 8px;
+  border: 1px solid #d4d4d4;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+}
+
+.profile_actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.preview {
+  margin-top: 24px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.preview button {
+  padding: 8px 14px;
+  border: 1px solid #d4d4d4;
+  background: #fafafa;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  margin-bottom: 12px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: #1a1a1a;
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+```
+
+- [ ] **Step 3: Create `playground/sandbox/controls/Slider.tsx`**
+
+```tsx
+import styles from "../styles.module.css";
+
+type Props = {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+  format?: (value: number) => string;
+};
+
+const Slider = ({ label, value, min, max, step, onChange, format }: Props) => (
+  <div className={styles.control_row}>
+    <label>{label}</label>
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+    <span className={styles.value}>{format ? format(value) : value}</span>
+  </div>
+);
+
+export default Slider;
+```
+
+- [ ] **Step 4: Create `playground/sandbox/controls/Toggle.tsx`**
+
+```tsx
+import styles from "../styles.module.css";
+
+type Props = {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+const Toggle = ({ label, checked, onChange }: Props) => (
+  <label className={styles.toggle_row}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+    <span>{label}</span>
+  </label>
+);
+
+export default Toggle;
+```
+
+- [ ] **Step 5: Create `playground/sandbox/controls/Select.tsx`**
+
+```tsx
+import styles from "../styles.module.css";
+
+type Option<T extends string> = { value: T; label: string };
+
+type Props<T extends string> = {
+  label: string;
+  value: T;
+  options: Option<T>[];
+  onChange: (value: T) => void;
+};
+
+const Select = <T extends string>({ label, value, options, onChange }: Props<T>) => (
+  <div className={styles.select_row}>
+    <label>{label}</label>
+    <select value={value} onChange={(e) => onChange(e.target.value as T)}>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+export default Select;
+```
+
+- [ ] **Step 6: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add playground/sandbox/types.ts playground/sandbox/controls/ playground/sandbox/styles.module.css
+git commit -m "$(cat <<'EOF'
+Add sandbox types and control primitives
+
+- TSandboxConfig, TProfilesStore, INITIAL_CONFIG
+- Slider, Toggle, Select primitives (native inputs + CSS module)
+- Sandbox layout styles
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: useProfiles localStorage hook
+
+**Files:**
+- Create: `playground/sandbox/useProfiles.ts`
+
+- [ ] **Step 1: Create `playground/sandbox/useProfiles.ts`**
+
+```ts
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TProfilesStore, TSandboxConfig } from "./types";
+
+const STORAGE_KEY = "collapsible-playground:profiles";
+const SCHEMA_VERSION = 1 as const;
+
+const emptyStore = (): TProfilesStore => ({
+  schemaVersion: SCHEMA_VERSION,
+  profiles: {},
+});
+
+const loadStore = (): { store: TProfilesStore; persistenceOk: boolean } => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { store: emptyStore(), persistenceOk: true };
+    const parsed = JSON.parse(raw) as TProfilesStore;
+    if (parsed.schemaVersion !== SCHEMA_VERSION) {
+      return { store: emptyStore(), persistenceOk: true };
+    }
+    return { store: parsed, persistenceOk: true };
+  } catch {
+    return { store: emptyStore(), persistenceOk: false };
+  }
+};
+
+const saveStore = (store: TProfilesStore): boolean => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export type TUseProfiles = {
+  list: () => string[];
+  save: (name: string, config: TSandboxConfig) => void;
+  load: (name: string) => TSandboxConfig | undefined;
+  remove: (name: string) => void;
+  exists: (name: string) => boolean;
+  persistenceOk: boolean;
+};
+
+export const useProfiles = (): TUseProfiles => {
+  const initial = useRef(loadStore());
+  const [store, setStore] = useState<TProfilesStore>(initial.current.store);
+  const [persistenceOk, setPersistenceOk] = useState(initial.current.persistenceOk);
+
+  useEffect(() => {
+    const ok = saveStore(store);
+    if (!ok) setPersistenceOk(false);
+  }, [store]);
+
+  const list = useCallback(
+    () => Object.keys(store.profiles).sort((a, b) => a.localeCompare(b)),
+    [store]
+  );
+
+  const save = useCallback(
+    (name: string, config: TSandboxConfig) => {
+      setStore((prev) => ({
+        ...prev,
+        profiles: { ...prev.profiles, [name]: config },
+      }));
+    },
+    []
+  );
+
+  const load = useCallback(
+    (name: string): TSandboxConfig | undefined => {
+      const entry = store.profiles[name];
+      return entry ? { ...entry, heightConfig: { ...entry.heightConfig } } : undefined;
+    },
+    [store]
+  );
+
+  const remove = useCallback((name: string) => {
+    setStore((prev) => {
+      const next = { ...prev.profiles };
+      delete next[name];
+      return { ...prev, profiles: next };
+    });
+  }, []);
+
+  const exists = useCallback((name: string) => name in store.profiles, [store]);
+
+  return { list, save, load, remove, exists, persistenceOk };
+};
+```
+
+- [ ] **Step 2: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add playground/sandbox/useProfiles.ts
+git commit -m "$(cat <<'EOF'
+Add useProfiles hook for sandbox profile persistence
+
+- localStorage-backed CRUD: list/save/load/remove/exists
+- Schema versioning (v1) — older/missing data resets to empty
+- persistenceOk flag flips false when localStorage throws,
+  letting UI show a non-blocking notice
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: ControlsPanel + ProfilesPanel
+
+**Files:**
+- Create: `playground/sandbox/ControlsPanel.tsx`
+- Create: `playground/sandbox/ProfilesPanel.tsx`
+
+- [ ] **Step 1: Create `playground/sandbox/ControlsPanel.tsx`**
+
+```tsx
+import { TAnimationPreset, PRESETS } from "../../src";
+import { TSandboxConfig } from "./types";
+import Slider from "./controls/Slider";
+import Toggle from "./controls/Toggle";
+import Select from "./controls/Select";
+import styles from "./styles.module.css";
+
+type Props = {
+  value: TSandboxConfig;
+  onChange: (next: TSandboxConfig) => void;
+};
+
+const PRESET_OPTIONS: Array<{ value: TAnimationPreset; label: string }> = [
+  { value: "gentle", label: "gentle" },
+  { value: "wobbly", label: "wobbly" },
+  { value: "stiff", label: "stiff" },
+];
+
+const ControlsPanel = ({ value, onChange }: Props) => {
+  const setHeight = (key: "mass" | "tension" | "friction", n: number) =>
+    onChange({
+      ...value,
+      heightConfig: { ...value.heightConfig, [key]: n },
+    });
+
+  const setPreset = (preset: TAnimationPreset) =>
+    onChange({
+      ...value,
+      preset,
+      heightConfig: { ...PRESETS[preset] },
+    });
+
+  return (
+    <section className={styles.panel}>
+      <h2 className={styles.panel_title}>Controls</h2>
+
+      <Select
+        label="preset"
+        value={value.preset}
+        options={PRESET_OPTIONS}
+        onChange={setPreset}
+      />
+
+      <Slider
+        label="mass"
+        min={0.1}
+        max={5}
+        step={0.1}
+        value={value.heightConfig.mass}
+        onChange={(n) => setHeight("mass", n)}
+        format={(n) => n.toFixed(1)}
+      />
+      <Slider
+        label="tension"
+        min={1}
+        max={500}
+        step={1}
+        value={value.heightConfig.tension}
+        onChange={(n) => setHeight("tension", n)}
+      />
+      <Slider
+        label="friction"
+        min={1}
+        max={100}
+        step={1}
+        value={value.heightConfig.friction}
+        onChange={(n) => setHeight("friction", n)}
+      />
+      <Slider
+        label="opacity (ms)"
+        min={0}
+        max={2000}
+        step={50}
+        value={value.opacityDuration}
+        onChange={(n) => onChange({ ...value, opacityDuration: n })}
+      />
+      <Slider
+        label="minHeight"
+        min={0}
+        max={200}
+        step={5}
+        value={value.minHeight}
+        onChange={(n) => onChange({ ...value, minHeight: n })}
+      />
+
+      <div style={{ marginTop: 12 }}>
+        <Toggle
+          label="isAnimateOpacity"
+          checked={value.isAnimateOpacity}
+          onChange={(b) => onChange({ ...value, isAnimateOpacity: b })}
+        />
+        <Toggle
+          label="isAnimateHeight"
+          checked={value.isAnimateHeight}
+          onChange={(b) => onChange({ ...value, isAnimateHeight: b })}
+        />
+        <Toggle
+          label="isOverflowHidden"
+          checked={value.isOverflowHidden}
+          onChange={(b) => onChange({ ...value, isOverflowHidden: b })}
+        />
+        <Toggle
+          label="isContentSelectable"
+          checked={value.isContentSelectable}
+          onChange={(b) => onChange({ ...value, isContentSelectable: b })}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default ControlsPanel;
+```
+
+- [ ] **Step 2: Create `playground/sandbox/ProfilesPanel.tsx`**
+
+```tsx
+import { useState } from "react";
+import { TSandboxConfig, INITIAL_CONFIG } from "./types";
+import { TUseProfiles } from "./useProfiles";
+import styles from "./styles.module.css";
+
+type Props = {
+  profiles: TUseProfiles;
+  currentConfig: TSandboxConfig;
+  onLoad: (config: TSandboxConfig) => void;
+};
+
+const ProfilesPanel = ({ profiles, currentConfig, onLoad }: Props) => {
+  const [draftName, setDraftName] = useState("");
+
+  const handleSave = () => {
+    const name = draftName.trim();
+    if (!name) return;
+    if (profiles.exists(name)) {
+      const ok = window.confirm(`Profile "${name}" already exists. Overwrite?`);
+      if (!ok) return;
+    }
+    profiles.save(name, currentConfig);
+    setDraftName("");
+  };
+
+  const handleDelete = (name: string) => {
+    const ok = window.confirm(`Delete profile "${name}"?`);
+    if (ok) profiles.remove(name);
+  };
+
+  const items = profiles.list();
+
+  return (
+    <section className={styles.panel}>
+      <h2 className={styles.panel_title}>Profiles</h2>
+
+      {items.length === 0 ? (
+        <p style={{ margin: "0 0 12px", color: "#6b6b6b", fontSize: "0.85rem" }}>
+          No saved profiles yet. Tweak the controls and save them with a name.
+        </p>
+      ) : (
+        <ul className={styles.profiles_list}>
+          {items.map((name) => (
+            <li key={name} className={styles.profile_item}>
+              <span>{name}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  const cfg = profiles.load(name);
+                  if (cfg) onLoad(cfg);
+                }}
+              >
+                Load
+              </button>
+              <button type="button" onClick={() => handleDelete(name)}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className={styles.profile_actions}>
+        <input
+          type="text"
+          placeholder="Profile name"
+          value={draftName}
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+          }}
+          style={{ flex: 1, padding: "6px 8px", border: "1px solid #d4d4d4", borderRadius: 4 }}
+        />
+        <button type="button" onClick={handleSave}>
+          Save as…
+        </button>
+        <button type="button" onClick={() => onLoad(INITIAL_CONFIG)}>
+          Reset
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ProfilesPanel;
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add playground/sandbox/ControlsPanel.tsx playground/sandbox/ProfilesPanel.tsx
+git commit -m "$(cat <<'EOF'
+Add ControlsPanel and ProfilesPanel
+
+- ControlsPanel: preset selector + 5 sliders + 4 toggles
+  Changing preset replaces mass/tension/friction sliders
+- ProfilesPanel: list of saved profiles with Load/Delete,
+  Save as... with name input, Reset to INITIAL_CONFIG
+  Overwrite confirm via window.confirm
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Sandbox composite + wire into App
+
+**Files:**
+- Create: `playground/sandbox/Sandbox.tsx`
+- Modify: `playground/App.tsx`
+
+- [ ] **Step 1: Create `playground/sandbox/Sandbox.tsx`**
+
+```tsx
+import { useState } from "react";
+import { Collapsible } from "../../src";
+import { TSandboxConfig, INITIAL_CONFIG } from "./types";
+import { useProfiles } from "./useProfiles";
+import ControlsPanel from "./ControlsPanel";
+import ProfilesPanel from "./ProfilesPanel";
+import { getContent } from "../examples/shared/content";
+import styles from "./styles.module.css";
+
+const Sandbox = () => {
+  const [config, setConfig] = useState<TSandboxConfig>(INITIAL_CONFIG);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const profiles = useProfiles();
+
+  return (
+    <section>
+      <h1>Sandbox</h1>
+      <p style={{ margin: "0 0 24px", color: "#4a4a4a", fontSize: "0.95rem" }}>
+        Live tweak every Collapsible knob and persist named profiles in localStorage.
+      </p>
+
+      <div className={styles.layout}>
+        <ControlsPanel value={config} onChange={setConfig} />
+        <ProfilesPanel
+          profiles={profiles}
+          currentConfig={config}
+          onLoad={setConfig}
+        />
+      </div>
+
+      <div className={styles.preview}>
+        <button type="button" onClick={() => setIsExpanded((p) => !p)}>
+          {isExpanded ? "Close preview" : "Open preview"}
+        </button>
+        <Collapsible
+          isExpanded={isExpanded}
+          setIsExpanded={setIsExpanded}
+          animationPreset={config.preset}
+          animationHeightConfig={config.heightConfig}
+          animationOpacityConfig={{ duration: config.opacityDuration }}
+          isAnimateOpacity={config.isAnimateOpacity}
+          isAnimateHeight={config.isAnimateHeight}
+          isOverflowHidden={config.isOverflowHidden}
+          isContentSelectable={config.isContentSelectable}
+          minHeight={config.minHeight}
+          content={
+            <div style={{ padding: 12, background: "#f7f7f7", borderRadius: 6 }}>
+              {getContent("medium")}
+            </div>
+          }
+        />
+      </div>
+
+      {!profiles.persistenceOk && (
+        <div className={styles.toast}>
+          localStorage is unavailable — profiles will not persist across reload.
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default Sandbox;
+```
+
+- [ ] **Step 2: Update `playground/App.tsx`**
+
+```tsx
+import { useState } from "react";
+import Sidebar, { TView } from "./nav/Sidebar";
+import { REGISTRY } from "./examples/registry";
+import Sandbox from "./sandbox/Sandbox";
+
+const App = () => {
+  const [view, setView] = useState<TView>("presets");
+
+  const Body = view === "sandbox" ? Sandbox : REGISTRY[view];
+
+  return (
+    <div className="app__layout">
+      <Sidebar active={view} onChange={setView} />
+      <main className="app__main">
+        <Body />
+      </main>
+    </div>
+  );
+};
+
+export default App;
+```
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Manual verify the sandbox**
+
+Run: `npm run dev`. Click "Sandbox" in the sidebar.
+
+- The Controls panel shows a preset dropdown, five sliders, four toggles.
+- The Preview area shows a button "Open preview" plus a Collapsible.
+- Clicking the button toggles the collapsible. Changing the `tension` slider while open re-springs to the new value live.
+- Changing the preset dropdown moves the mass/tension/friction sliders to match.
+- Save as… "test-profile" → profile appears in the list.
+- Reload the page → "test-profile" still in the list.
+- Click Load on "test-profile" → sliders restore.
+- Delete the profile via Delete → confirm → it disappears.
+- Reset → controls revert to INITIAL_CONFIG.
+
+Stop with Ctrl+C.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add playground/sandbox/Sandbox.tsx playground/App.tsx
+git commit -m "$(cat <<'EOF'
+Add Sandbox composite and wire into App
+
+- Sandbox holds TSandboxConfig + isExpanded state
+- ControlsPanel + ProfilesPanel + live <Collapsible /> preview
+- Toast surfaces localStorage failure (private mode / quota)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: GitHub Actions deployment workflow
+
+**Files:**
+- Create: `.github/workflows/deploy-playground.yml`
+
+- [ ] **Step 1: Create the workflow file**
+
+```yaml
+name: Deploy Playground to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run playground:build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./playground-dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+- [ ] **Step 2: Verify the playground build locally**
+
+Run: `npm run playground:build`
+Expected: `playground-dist/index.html` is created. Open it in a text editor and confirm asset paths reference `/collapsible/`.
+
+Run: `grep -o 'src="[^"]*"' playground-dist/index.html`
+Expected: paths starting with `/collapsible/assets/`.
+
+- [ ] **Step 3: Verify build output**
+
+Run: `npm run playground:preview`
+Expected: starts a static server. The preview will serve under `/collapsible/` so it may not work as-is at root — that's fine; the published GitHub Pages URL (`/collapsible/`) is what matters.
+
+Stop with Ctrl+C.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/deploy-playground.yml
+git commit -m "$(cat <<'EOF'
+Add GitHub Pages deployment workflow
+
+- Build playground on push to main
+- Lint check before build
+- Modern Pages flow via actions/deploy-pages@v4 (no gh-pages branch)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: README and migration notes
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Replace `README.md`**
+
+```markdown
+# Collapsible
+
+A small, focused React component for collapse/expand interactions, animated by [react-spring](https://www.react-spring.dev/).
+
+🎨 **Live playground:** https://kolosochek.github.io/collapsible/
+
+## Install
+
+```bash
+npm install collapsible @react-spring/web
+```
+
+`react`, `react-dom`, and `@react-spring/web` are peer dependencies.
+
+## Usage
+
+```tsx
+import { useState } from "react";
+import { Collapsible } from "collapsible";
+
+const App = () => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <>
+      <button onClick={() => setIsExpanded((p) => !p)}>Toggle</button>
+      <Collapsible
+        isExpanded={isExpanded}
+        setIsExpanded={setIsExpanded}
+        content={<p>Content goes here.</p>}
+      />
+    </>
+  );
+};
+```
+
+## Animation presets
+
+The component ships three named presets that match react-spring's built-in named configs:
+
+| Preset | mass | tension | friction | Character |
+|---|---|---|---|---|
+| `gentle` (default) | 1 | 120 | 14 | Soft, no overshoot |
+| `wobbly` | 1 | 180 | 12 | Visible bounce |
+| `stiff` | 1 | 210 | 20 | Fast, crisp |
+
+```tsx
+<Collapsible animationPreset="wobbly" /* ... */ />
+```
+
+Override individual keys with `animationHeightConfig` — explicit values win per-key:
+
+```tsx
+<Collapsible
+  animationPreset="wobbly"
+  animationHeightConfig={{ tension: 300 }}  // wobbly mass + friction, custom tension
+/>
+```
+
+## Migrating from 1.x
+
+The default animation config changed in 2.0.0. v1 used `{ mass: 1, tension: 176, friction: 26 }` — close to react-spring's `default`. v2 uses the new `gentle` preset (`{ mass: 1, tension: 120, friction: 14 }`).
+
+To restore exact v1 behavior:
+
+```tsx
+<Collapsible
+  animationHeightConfig={{ mass: 1, tension: 176, friction: 26 }}
+  /* ... */
+/>
+```
+
+Also: importing the package in v1 inadvertently called `ReactDOM.createRoot` because the lib entry doubled as a demo. v2 ships an exports-only entry; this side-effect is gone.
+
+## Local development
+
+```bash
+npm install
+npm run dev          # Vite playground at http://localhost:5173/
+npm run lint         # tsc --noEmit
+npm run build        # tsup library build into dist/
+```
+
+## Deploying the playground
+
+The playground deploys to GitHub Pages automatically on push to `main` via `.github/workflows/deploy-playground.yml`. First-time setup: in the repo's **Settings → Pages**, set **Source** to **GitHub Actions**.
+
+## License
+
+GPL-3.0-or-later — see [LICENSE](./LICENSE).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add README.md
+git commit -m "$(cat <<'EOF'
+Rewrite README for v2 and the new playground
+
+- Document the three animation presets
+- Migration section for 1.x consumers
+- Note the v1 lib-entry side-effect fix
+- Local dev / build / deploy commands
+- Link to live GitHub Pages playground
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Final verification
+
+This task does not modify code — it runs the manual verification checklist from the spec end-to-end.
+
+- [ ] **Step 1: Clean install**
+
+Run: `rm -rf node_modules dist playground-dist && npm install`
+Expected: completes without errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: zero errors across `src/` + `playground/`.
+
+- [ ] **Step 3: Library build**
+
+Run: `npm run build`
+Expected: `dist/index.js`, `dist/index.mjs`, `dist/index.d.ts` exist.
+
+Run: `grep -c "createRoot" dist/index.mjs || echo 0`
+Expected: `0`.
+
+- [ ] **Step 4: Playground build**
+
+Run: `npm run playground:build`
+Expected: `playground-dist/index.html` exists.
+
+Run: `grep -o '/collapsible/assets/[^"]*' playground-dist/index.html | head -3`
+Expected: at least one matching path is printed.
+
+- [ ] **Step 5: Dev server smoke (golden path)**
+
+Run: `npm run dev`. At `http://localhost:5173/`:
+
+| Check | Expected |
+|---|---|
+| Sidebar renders six items in two groups | yes |
+| 1. Presets — Open all → all three cards expand with visibly different easing | yes |
+| 2. Mass spectrum — open mass=0.5 vs mass=5 | mass=5 noticeably slower to start |
+| 3. Tension spectrum — open tension=80 vs tension=400 | tension=400 noticeably faster |
+| 4. Friction spectrum — open friction=8 vs friction=60 | friction=8 visibly bounces |
+| 5. FAQ Accordion — open tab 1, then tab 2 | tab 1 collapses |
+| Sandbox — drag tension slider while preview open | preview re-springs live |
+| Sandbox — Save as "test" → reload page | "test" still in profiles list |
+| Sandbox — load "test" | controls + preview restore |
+| Sandbox — Reset | controls revert to defaults |
+
+Stop with Ctrl+C.
+
+- [ ] **Step 6: Push and verify deploy**
+
+Push the feature branch and open a PR (or, if working directly on main, push to main). After merging to main:
+
+- The GitHub Actions workflow runs (`Deploy Playground to GitHub Pages`).
+- First-time setup if needed: **Settings → Pages → Source → GitHub Actions**.
+- After the workflow succeeds, visit `https://kolosochek.github.io/collapsible/` and re-run the smoke checks from Step 5.
+
+This step requires GitHub credentials and is performed by the maintainer — not by the implementing agent.
+
+- [ ] **Step 7: No commit needed**
+
+Verification only — no code changes in this task.
+
+---
+
+## Summary of commits in execution order
+
+1. `Configure Vite + tsup tooling and bump deps`
+2. `Bootstrap Vite playground with placeholder App`
+3. `Add animation presets module`
+4. `Add animationPreset prop and clean library entry`
+5. `Add sidebar nav and view switching in playground`
+6. `Add shared example primitives`
+7. `Add five example pages and registry`
+8. `Add sandbox types and control primitives`
+9. `Add useProfiles hook for sandbox profile persistence`
+10. `Add ControlsPanel and ProfilesPanel`
+11. `Add Sandbox composite and wire into App`
+12. `Add GitHub Pages deployment workflow`
+13. `Rewrite README for v2 and the new playground`
+14. (no commit — verification only)
+
+---
+
+## Spec coverage check (self-review)
+
+| Spec section / requirement | Task |
+|---|---|
+| §3.1 Repository layout | T1, T2, T6, T7, T8, T10, T11, T12 |
+| §3.2 Library / playground separation | T1 (`tsconfig.lib.json`, `tsup.config.ts`) |
+| §4.1 Presets file | T3 |
+| §4.2 Prop API + override semantics | T4 |
+| §4.3 `Collapsible.tsx` internals | T4 |
+| §4.4 Library entry rewrite | T4 |
+| §4.5 Versioning (2.0.0) | T1 |
+| §5.1 Vite config | T2 |
+| §5.2 Layout + nav | T5 |
+| §5.3 Five examples | T7 (and T6 shared) |
+| §5.4.1 State shape | T8 |
+| §5.4.2 useProfiles | T9 |
+| §5.4.3 Slider ranges + INITIAL_CONFIG | T8 |
+| §5.4.4 Boolean toggles | T10 |
+| §5.4.5 Preset selector behavior | T10 |
+| §5.5 Native control primitives | T8 |
+| §6.1 package.json | T1 |
+| §6.2–6.4 tsconfig / tsconfig.lib / tsup | T1 |
+| §7 GH Actions workflow | T12 |
+| §8 README updates | T13 |
+| §9 Manual verification | T14 |
+| §10 Risks (peer deps, lib entry, base path, localStorage, CSS, GH Pages, lint scope) | mitigations applied across T1, T4, T2, T9, T6, T13, T1 |
+| §11 O1 (no auto-load lastUsed) | T8 (`INITIAL_CONFIG` always boots) |
+| §11 O2 (no URL share) | not implemented — explicit deferral |
+| §11 O3 (no test runner) | not implemented — explicit deferral |

--- a/docs/superpowers/specs/2026-05-02-collapsible-examples-design.md
+++ b/docs/superpowers/specs/2026-05-02-collapsible-examples-design.md
@@ -1,0 +1,451 @@
+# Collapsible — Examples, Sandbox, Animation Presets and GitHub Pages
+
+**Date:** 2026-05-02
+**Status:** Design (approved)
+**Author:** Dmitriy Kolosovskiy (with Claude)
+
+## 1. Goals
+
+1. Showcase the expressive range of `react-spring` through a curated set of static examples.
+2. Provide an interactive sandbox with parameter sliders and named profiles persisted to `localStorage`.
+3. Add three first-class animation presets (`gentle`, `wobbly`, `stiff`) to the `<Collapsible />` component, switchable via prop, with a default value.
+4. Host the playground on GitHub Pages at `https://kolosochek.github.io/collapsible/`.
+
+## 2. Non-goals
+
+- Test runner / CI test suite (no testing infrastructure exists today; adding one is out of scope).
+- Storybook or other documentation framework.
+- React Router or any client-side routing inside the playground.
+- URL-shareable sandbox state (deferred — `localStorage`-only persistence in v1).
+- Migration shims for the v1 default animation config; consumers opt back via explicit `animationHeightConfig`.
+
+## 3. Architecture
+
+### 3.1 Repository layout
+
+```
+collapsible/
+├── .github/
+│   └── workflows/
+│       └── deploy-playground.yml
+├── src/                              # library
+│   ├── index.tsx                     # exports only — no React render
+│   ├── components/
+│   │   └── Collapsible/
+│   │       ├── Collapsible.tsx
+│   │       ├── presets.ts            # NEW
+│   │       └── styles.module.css
+│   └── types/
+│       ├── collapsible.ts
+│       └── typeguards.ts
+├── playground/                       # demo app (Vite)
+│   ├── index.html
+│   ├── main.tsx
+│   ├── App.tsx
+│   ├── nav/
+│   │   └── Sidebar.tsx
+│   ├── examples/
+│   │   ├── PresetsExample.tsx
+│   │   ├── MassSpectrumExample.tsx
+│   │   ├── TensionSpectrumExample.tsx
+│   │   ├── FrictionSpectrumExample.tsx
+│   │   ├── AccordionExample.tsx
+│   │   ├── shared/
+│   │   │   ├── ExamplePage.tsx
+│   │   │   ├── ConfigCard.tsx
+│   │   │   └── content.ts
+│   │   └── registry.ts
+│   ├── sandbox/
+│   │   ├── Sandbox.tsx
+│   │   ├── ControlsPanel.tsx
+│   │   ├── ProfilesPanel.tsx
+│   │   ├── useProfiles.ts
+│   │   ├── controls/
+│   │   │   ├── Slider.tsx
+│   │   │   ├── Toggle.tsx
+│   │   │   └── Select.tsx
+│   │   ├── types.ts
+│   │   └── styles.module.css
+│   └── styles/
+│       └── global.css
+├── vite.config.ts
+├── tsconfig.json
+├── tsconfig.lib.json
+├── tsup.config.ts
+├── package.json
+└── README.md
+```
+
+`public/index.html` is removed — its role is replaced by `playground/index.html`.
+
+### 3.2 Library / playground separation
+
+- `src/` is the published npm package. Built by `tsup` into `dist/`.
+- `playground/` is a Vite app that imports `Collapsible` from `'../src'` (path alias resolved by Vite). Never bundled into the library.
+- `tsconfig.lib.json` is consumed by `tsup`; it includes `src/` and excludes `playground/` so the playground is never type-checked as part of a library build.
+- The root `tsconfig.json` includes both `src` and `playground` so editor tooling and `npm run lint` cover the whole repo.
+
+## 4. Library changes
+
+### 4.1 Animation presets
+
+Three named presets, exported from `src/components/Collapsible/presets.ts`:
+
+```ts
+import { SpringConfig } from "@react-spring/web";
+
+export const PRESETS = {
+  gentle: { mass: 1, tension: 120, friction: 14 },
+  wobbly: { mass: 1, tension: 180, friction: 12 },
+  stiff:  { mass: 1, tension: 210, friction: 20 },
+} as const satisfies Record<string, SpringConfig>;
+
+export type TAnimationPreset = keyof typeof PRESETS;
+```
+
+Names mirror `react-spring`'s built-in named configs so consumers familiar with the library transfer their intuition.
+
+### 4.2 Prop API
+
+A new prop on `<Collapsible />`:
+
+```ts
+animationPreset?: TAnimationPreset;   // default: "gentle"
+```
+
+Resolution rule for the height-spring config:
+
+```ts
+const resolvedHeightConfig: SpringConfig = {
+  ...PRESETS[animationPreset],
+  ...animationHeightConfig,           // explicit prop wins per-key
+};
+```
+
+Behavior:
+- `<Collapsible />` — uses `gentle`.
+- `<Collapsible animationPreset="wobbly" />` — uses `wobbly`.
+- `<Collapsible animationPreset="wobbly" animationHeightConfig={{ tension: 300 }} />` — wobbly mass/friction with overridden tension.
+- `<Collapsible animationHeightConfig={{ mass: 1, tension: 176, friction: 26 }} />` — full v1-compatible behavior.
+
+The opacity spring is unaffected; it continues to use `animationOpacityConfig` (default `{ duration: 250 }`).
+
+### 4.3 Internals (`Collapsible.tsx`)
+
+Single point of change: replace the literal default for `animationHeightConfig` with `animationPreset = "gentle"`, compute `resolvedHeightConfig` once per render, and pass it through to the existing `useSpring` config callback for the `"height"` key. No other rendering logic changes.
+
+### 4.4 Library entry (`src/index.tsx`)
+
+Replaces the current React-rendering entry with pure exports:
+
+```ts
+export { default as Collapsible } from "./components/Collapsible/Collapsible";
+export { PRESETS } from "./components/Collapsible/presets";
+export type { TAnimationPreset } from "./components/Collapsible/presets";
+export type { TCollapsibleProps } from "./types/collapsible";
+```
+
+This fixes a v1 bug: importing the published package previously executed `ReactDOM.createRoot(...)` because the lib entry doubled as the demo. The fix lands in the same major bump.
+
+### 4.5 Versioning
+
+Major bump 1.0.0 → 2.0.0:
+- New default config (`gentle` vs current `{tension:176, friction:26}`) for consumers not passing `animationHeightConfig`.
+- Removed React-render side-effect from the lib entry.
+
+A "Migrating from 1.x" section in the README explains how to restore v1 behavior:
+
+```tsx
+<Collapsible animationHeightConfig={{ mass: 1, tension: 176, friction: 26 }} />
+```
+
+## 5. Playground
+
+### 5.1 Vite configuration
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  root: "playground",
+  base: "/collapsible/",
+  build: {
+    outDir: "../playground-dist",
+    emptyOutDir: true,
+  },
+  server: { port: 5173, open: true },
+});
+```
+
+`base` only applies to `vite build`; local `vite` dev server serves from `/`.
+
+### 5.2 Layout and navigation
+
+`App.tsx` holds a single `useState<TView>` and renders a sidebar plus a content area. No router.
+
+```ts
+type TView = "presets" | "mass" | "tension" | "friction" | "accordion" | "sandbox";
+```
+
+Layout: 280px sidebar on the left, max-width 960px content area on the right, sticky header per view with the example title.
+
+### 5.3 Examples (5 pages)
+
+Each example uses a shared `ExamplePage` wrapper (title + lead description + grid of cards) and `ConfigCard` (a header that toggles a `<Collapsible />` underneath, labeled with the parameter being demonstrated).
+
+| # | View id | File | Demonstrates | Layout |
+|---|---|---|---|---|
+| 1 | `presets` | `PresetsExample.tsx` | `animationPreset="gentle"\|"wobbly"\|"stiff"` plus a "Toggle all" button to fire all cards simultaneously | grid 3 cols |
+| 2 | `mass` | `MassSpectrumExample.tsx` | `mass: 0.5 / 1 / 2 / 5` at fixed `tension=180, friction=18` | grid 4 cols |
+| 3 | `tension` | `TensionSpectrumExample.tsx` | `tension: 80 / 150 / 220 / 400` at fixed `mass=1, friction=18` | grid 4 cols |
+| 4 | `friction` | `FrictionSpectrumExample.tsx` | `friction: 8 / 16 / 26 / 60` at fixed `mass=1, tension=180` | grid 4 cols |
+| 5 | `accordion` | `AccordionExample.tsx` | `isAccordion=true` with three FAQ tabs, `animationPreset="wobbly"` | vertical stack |
+
+Each card uses one of three lorem snippets (short / medium / long) from `examples/shared/content.ts`. Spectrum examples use `medium` to keep heights comparable.
+
+### 5.4 Sandbox
+
+#### 5.4.1 State shape
+
+```ts
+// playground/sandbox/types.ts
+export type TSandboxConfig = {
+  preset: TAnimationPreset;
+  heightConfig: { mass: number; tension: number; friction: number };
+  opacityDuration: number;
+  isAnimateOpacity: boolean;
+  isAnimateHeight: boolean;
+  isOverflowHidden: boolean;
+  isContentSelectable: boolean;
+  minHeight: number;
+};
+
+export type TProfilesStore = {
+  schemaVersion: 1;
+  profiles: Record<string, TSandboxConfig>;
+};
+```
+
+#### 5.4.2 Persistence (`useProfiles`)
+
+- Storage key: `collapsible-playground:profiles`.
+- On mount: read `localStorage`. If missing or `schemaVersion !== 1`, start with an empty store. No migration logic in v1.
+- Mutations are flushed synchronously via `localStorage.setItem`. All access wrapped in `try/catch` — on failure the profile lives in memory only and a toast informs the user that persistence is disabled.
+- API: `save(name, config)`, `load(name)`, `remove(name)`, `list()`. `save` with an existing name overwrites; the UI prompts for confirmation before calling `save` in that case.
+
+#### 5.4.3 Slider ranges and initial values
+
+| Control | min | max | step | initial |
+|---|---|---|---|---|
+| mass | 0.1 | 5 | 0.1 | 1 |
+| tension | 1 | 500 | 1 | 180 |
+| friction | 1 | 100 | 1 | 18 |
+| opacityDuration | 0 | 2000 | 50 | 250 |
+| minHeight | 0 | 200 | 5 | 0 |
+
+v1 always boots with these `initial` values regardless of whether saved profiles exist. Auto-loading the most-recently-used profile on mount is deferred (see §11 O1).
+
+#### 5.4.4 Boolean toggles
+
+- `isAnimateOpacity` (default `true`)
+- `isAnimateHeight` (default `true`)
+- `isOverflowHidden` (default `true`)
+- `isContentSelectable` (default `true`)
+
+#### 5.4.5 Preset selector
+
+A `<select>` with `gentle / wobbly / stiff`. When the selector changes:
+- `config.preset` is updated.
+- `config.heightConfig` mass/tension/friction are *replaced* with the preset values, so the sliders move to reflect the chosen preset.
+- After the user moves a slider, `heightConfig` diverges from the preset — that's expected and matches the override semantics in the library.
+
+### 5.5 Slider, Toggle, Select primitives
+
+Native HTML `<input type="range">`, `<input type="checkbox">`, `<select>` styled via CSS modules. No external UI library. Each primitive renders its current value beside the control.
+
+## 6. Tooling
+
+### 6.1 `package.json`
+
+```jsonc
+{
+  "name": "collapsible",
+  "version": "2.0.0",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "scripts": {
+    "dev": "vite",
+    "lint": "tsc --noEmit",
+    "build": "tsup --config tsup.config.ts",
+    "playground:build": "vite build",
+    "playground:preview": "vite preview"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18",
+    "@react-spring/web": "^9.7.5"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "tsup": "^8.3.5",
+    "typescript": "latest",
+    "react": "latest",
+    "react-dom": "latest",
+    "@react-spring/web": "^9.7.5",
+    "@types/react": "latest",
+    "@types/react-dom": "latest"
+  }
+}
+```
+
+Notes:
+- `tsup`, `react`, `react-dom`, `@react-spring/web` move from `dependencies` to `devDependencies` (and the latter three are re-declared as `peerDependencies`). This ships the package without forcing duplicate copies on consumers.
+- `files` ensures only the built `dist/` is published.
+
+### 6.2 `tsconfig.json`
+
+Two changes:
+- `"jsx": "react-jsx"` (was `"react"`). Modern JSX transform — no need to import React in every file.
+- `"include": ["src", "playground"]`.
+
+### 6.3 `tsconfig.lib.json` (new)
+
+```jsonc
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false, "declaration": true },
+  "include": ["src"],
+  "exclude": ["playground"]
+}
+```
+
+### 6.4 `tsup.config.ts` (new)
+
+```ts
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.tsx"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  external: ["react", "react-dom", "@react-spring/web"],
+});
+```
+
+## 7. GitHub Pages deployment
+
+`.github/workflows/deploy-playground.yml`:
+
+```yaml
+name: Deploy Playground to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run playground:build
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./playground-dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+```
+
+One-time manual setup in GitHub UI: Settings → Pages → Source: **GitHub Actions**. This is documented in the updated README.
+
+## 8. README updates
+
+- Add a short "Animation presets" section with a `<Collapsible animationPreset="..." />` example.
+- Add a "Migrating from 1.x" section.
+- Add a "Playground" section linking to `https://kolosochek.github.io/collapsible/`.
+- Replace the CodeSandbox link with the GitHub Pages link.
+
+## 9. Verification (manual)
+
+| # | Action | Expected |
+|---|---|---|
+| 1 | `npm install` | Completes without errors |
+| 2 | `npm run lint` | `tsc --noEmit` passes for `src` + `playground` |
+| 3 | `npm run dev`, open `http://localhost:5173` | Sidebar + Presets example render |
+| 4 | Click each sidebar item | Each view renders without runtime errors |
+| 5 | Presets example: open all three cards | Visibly different easing per preset |
+| 6 | Mass / Tension / Friction examples | Spectrum cards open with visibly different character |
+| 7 | Accordion example: open tab 1, then tab 2 | Tab 1 collapses automatically |
+| 8 | Sandbox: drag tension slider | Live preview re-springs with the new tension |
+| 9 | Sandbox: "Save as…" → name → reload page | Profile persists, visible in profiles list |
+| 10 | Sandbox: load saved profile | Controls and live preview restore from the profile |
+| 11 | `npm run build` | `dist/index.{js,mjs,d.ts}` emitted; bundle does not call `ReactDOM.createRoot` |
+| 12 | `npm run playground:build` | `playground-dist/index.html` references `/collapsible/assets/...` |
+| 13 | Push to main → GH Actions green | Live URL `https://kolosochek.github.io/collapsible/` serves the playground |
+
+## 10. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Breaking change: default config flips from `{tension:176, friction:26}` to `gentle{120,14}` | Major bump 2.0.0 + "Migrating from 1.x" README section with the one-line restore snippet. |
+| v1 lib entry rendered React on import (bug) | Fixed in 2.0.0 as a side-effect of cleaning `src/index.tsx`. Documented in the major bump notes. |
+| `localStorage` unavailable (private mode, quota) | `useProfiles` wraps access in try/catch; profiles fall back to in-memory; UI shows "Persistence disabled" toast. |
+| CSS conflicts between playground and library | Library uses CSS modules under `src/components/...`; playground uses its own modules under `playground/...`. No global stylesheet from the library. |
+| GH Pages first deploy requires UI toggle | Documented in README; first deploy may require flipping Source to "GitHub Actions" once. |
+| `base: "/collapsible/"` could break local dev | Vite only applies `base` during `build`; dev server serves at `/`. Verified by Vite's documented behavior. |
+| Type-checking `playground/` slows CI | Acceptable; full repo lint is one `tsc --noEmit` run. If it becomes an issue, split into `lint:lib` and `lint:playground`. |
+
+## 11. Open questions / explicit deferrals
+
+- **O1.** Auto-loading the most-recently-used profile on mount is deferred to a future version. v1 always uses the hard-coded `initial` slider values from §5.4.3. `TProfilesStore` does not need a `lastUsed` field.
+- **O2.** URL-shareable sandbox state — explicitly deferred (see Non-goals).
+- **O3.** Test runner setup — explicitly deferred (see Non-goals).
+
+## 12. Summary of decisions
+
+| Decision | Choice |
+|---|---|
+| Project structure | Vite + `playground/` folder; library entry cleaned to exports only |
+| Preset names | `gentle / wobbly / stiff` (matches react-spring) |
+| Default preset | `"gentle"` |
+| Preset prop API | `animationPreset?: TAnimationPreset = "gentle"`; explicit `animationHeightConfig` overrides per-key |
+| Examples | 5 pages: Presets, Mass, Tension, Friction, FAQ Accordion |
+| Sandbox controls | Sliders for all numeric params, toggles for booleans, preset selector |
+| Sandbox persistence | Named profiles in `localStorage` (no URL share in v1) |
+| Navigation | Sidebar + `useState`, no router |
+| Sliders | Native `<input type="range">` styled via CSS modules |
+| Versioning | Major bump 1.0.0 → 2.0.0 |
+| Hosting | GitHub Pages from Actions, modern (no `gh-pages` branch) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2772 @@
+{
+  "name": "collapsible",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "collapsible",
+      "version": "2.0.0",
+      "license": "GPL-3.0-or-later",
+      "devDependencies": {
+        "@react-spring/web": "^9.7.5",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "tsup": "^8.3.5",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.0"
+      },
+      "peerDependencies": {
+        "@react-spring/web": "^9.7.5",
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@react-spring/animated": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
+      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/core": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
+      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-spring/donate"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/rafz": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
+      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/shared": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
+      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/rafz": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@react-spring/types": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
+      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@react-spring/web": {
+      "version": "9.7.5",
+      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
+      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@react-spring/animated": "~9.7.5",
+        "@react-spring/core": "~9.7.5",
+        "@react-spring/shared": "~9.7.5",
+        "@react-spring/types": "~9.7.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.25",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.25.tgz",
+      "integrity": "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001791",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
+      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.349",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
+      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,38 +1,44 @@
 {
   "name": "collapsible",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Collapse\\expand block for any react applications",
-  "main": "src/index.tsx",
+  "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.tsx --format cjs,esm --dts",
-    "lint": "tsc"
+    "dev": "vite",
+    "lint": "tsc --noEmit",
+    "build": "tsup --config tsup.config.ts",
+    "playground:build": "vite build",
+    "playground:preview": "vite preview"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kolosochek/collapsible.git#main"
   },
-  "keywords": [
-    "react",
-    "react-spring",
-    "collapse",
-    "expand",
-    "animation"
-  ],
+  "keywords": ["react", "react-spring", "collapse", "expand", "animation"],
   "author": "Dmitriy Kolosovskiy",
   "license": "GPL-3.0-or-later",
   "bugs": {
     "url": "https://github.com/kolosochek/collapsible/issues"
   },
-  "dependencies": {
-    "tsup": "^8.3.5",
-    "typescript": "latest",
-    "react-dom": "latest",
-    "react": "latest",
-    "@types/react-dom": "latest",
-    "@types/react": "latest",
+  "homepage": "https://github.com/kolosochek/collapsible/tree/main#readme",
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18",
     "@react-spring/web": "^9.7.5"
   },
-  "homepage": "https://github.com/kolosochek/collapsible/tree/main#readme"
+  "devDependencies": {
+    "@react-spring/web": "^9.7.5",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "tsup": "^8.3.5",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.0"
+  }
 }

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -1,8 +1,16 @@
+import { useState } from "react";
+import Sidebar, { TView } from "./nav/Sidebar";
+
 const App = () => {
+  const [view, setView] = useState<TView>("presets");
+
   return (
-    <div style={{ padding: 24 }}>
-      <h1>Collapsible — Playground</h1>
-      <p>Bootstrap OK. Sidebar and content come in Task 5.</p>
+    <div className="app__layout">
+      <Sidebar active={view} onChange={setView} />
+      <main className="app__main">
+        <h1>{view}</h1>
+        <p>View "{view}" — content arrives in later tasks.</p>
+      </main>
     </div>
   );
 };

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -1,15 +1,29 @@
 import { useState } from "react";
 import Sidebar, { TView } from "./nav/Sidebar";
+import { REGISTRY } from "./examples/registry";
 
 const App = () => {
   const [view, setView] = useState<TView>("presets");
+
+  if (view === "sandbox") {
+    return (
+      <div className="app__layout">
+        <Sidebar active={view} onChange={setView} />
+        <main className="app__main">
+          <h1>Sandbox</h1>
+          <p>Sandbox arrives in Tasks 8–12.</p>
+        </main>
+      </div>
+    );
+  }
+
+  const ActiveView = REGISTRY[view];
 
   return (
     <div className="app__layout">
       <Sidebar active={view} onChange={setView} />
       <main className="app__main">
-        <h1>{view}</h1>
-        <p>View "{view}" — content arrives in later tasks.</p>
+        <ActiveView />
       </main>
     </div>
   );

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -1,29 +1,18 @@
 import { useState } from "react";
 import Sidebar, { TView } from "./nav/Sidebar";
 import { REGISTRY } from "./examples/registry";
+import Sandbox from "./sandbox/Sandbox";
 
 const App = () => {
   const [view, setView] = useState<TView>("presets");
 
-  if (view === "sandbox") {
-    return (
-      <div className="app__layout">
-        <Sidebar active={view} onChange={setView} />
-        <main className="app__main">
-          <h1>Sandbox</h1>
-          <p>Sandbox arrives in Tasks 8–12.</p>
-        </main>
-      </div>
-    );
-  }
-
-  const ActiveView = REGISTRY[view];
+  const Body = view === "sandbox" ? Sandbox : REGISTRY[view];
 
   return (
     <div className="app__layout">
       <Sidebar active={view} onChange={setView} />
       <main className="app__main">
-        <ActiveView />
+        <Body />
       </main>
     </div>
   );

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -1,0 +1,10 @@
+const App = () => {
+  return (
+    <div style={{ padding: 24 }}>
+      <h1>Collapsible — Playground</h1>
+      <p>Bootstrap OK. Sidebar and content come in Task 5.</p>
+    </div>
+  );
+};
+
+export default App;

--- a/playground/examples/AccordionExample.tsx
+++ b/playground/examples/AccordionExample.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { Collapsible } from "../../src";
+import ExamplePage from "./shared/ExamplePage";
+import styles from "./shared/styles.module.css";
+
+const FAQ = [
+  {
+    id: "what",
+    question: "What is this library?",
+    answer:
+      "A small React component for collapse/expand interactions, animated by react-spring. " +
+      "It exposes a controlled isExpanded prop and a rich set of animation knobs.",
+  },
+  {
+    id: "physics",
+    question: "How does the animation work?",
+    answer:
+      "The component uses a react-spring useSpring hook to animate height and opacity. " +
+      "The height spring config is selected from a preset (gentle, wobbly, stiff) and can be " +
+      "overridden per-key via animationHeightConfig.",
+  },
+  {
+    id: "accordion",
+    question: "Can I use this as an accordion?",
+    answer:
+      "Yes — pass isAccordion=true and a shared openedTabId state. When one tab opens, " +
+      "the others collapse automatically.",
+  },
+];
+
+const AccordionExample = () => {
+  const [openedTabId, setOpenedTabId] = useState("");
+  const [expandedMap, setExpandedMap] = useState<Record<string, boolean>>({});
+
+  const setIsExpandedFor = (id: string) => (flag: boolean) => {
+    setExpandedMap((prev) => ({ ...prev, [id]: flag }));
+  };
+
+  return (
+    <ExamplePage
+      title="5. FAQ Accordion"
+      description="A real-world use of isAccordion=true with the wobbly preset. Opening one tab collapses the others."
+    >
+      <div className={`${styles.grid} ${styles.grid_1}`}>
+        {FAQ.map((item) => (
+          <article key={item.id} className={styles.card}>
+            <header
+              className={styles.card_header}
+              onClick={() => setIsExpandedFor(item.id)(!expandedMap[item.id])}
+            >
+              <span>{item.question}</span>
+              <span>{expandedMap[item.id] ? "▲" : "▼"}</span>
+            </header>
+            <Collapsible
+              isExpanded={!!expandedMap[item.id]}
+              setIsExpanded={setIsExpandedFor(item.id)}
+              isAccordion
+              accordionTabId={item.id}
+              openedTabId={openedTabId}
+              setOpenedTabId={setOpenedTabId}
+              animationPreset="wobbly"
+              content={<div className={styles.card_content}>{item.answer}</div>}
+            />
+          </article>
+        ))}
+      </div>
+    </ExamplePage>
+  );
+};
+
+export default AccordionExample;

--- a/playground/examples/FrictionSpectrumExample.tsx
+++ b/playground/examples/FrictionSpectrumExample.tsx
@@ -1,0 +1,24 @@
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const FRICTION_VALUES = [8, 16, 26, 60];
+
+const FrictionSpectrumExample = () => (
+  <ExamplePage
+    title="4. Friction spectrum"
+    description="Increasing friction at fixed mass (1) and tension (180). Lower friction lets the spring overshoot and bounce; higher friction critically damps it."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {FRICTION_VALUES.map((friction) => (
+        <ConfigCard
+          key={friction}
+          label={`friction: ${friction}`}
+          config={{ mass: 1, tension: 180, friction }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default FrictionSpectrumExample;

--- a/playground/examples/MassSpectrumExample.tsx
+++ b/playground/examples/MassSpectrumExample.tsx
@@ -1,0 +1,24 @@
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const MASS_VALUES = [0.5, 1, 2, 5];
+
+const MassSpectrumExample = () => (
+  <ExamplePage
+    title="2. Mass spectrum"
+    description="Increasing mass at fixed tension (180) and friction (18). Higher mass feels heavier and slower to start; lower mass feels light and snappy."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {MASS_VALUES.map((mass) => (
+        <ConfigCard
+          key={mass}
+          label={`mass: ${mass}`}
+          config={{ mass, tension: 180, friction: 18 }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default MassSpectrumExample;

--- a/playground/examples/PresetsExample.tsx
+++ b/playground/examples/PresetsExample.tsx
@@ -1,0 +1,45 @@
+import { useRef, useState } from "react";
+import { TAnimationPreset } from "../../src";
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard, { TSyncCommand } from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const PRESETS_LIST: TAnimationPreset[] = ["gentle", "wobbly", "stiff"];
+
+const PresetsExample = () => {
+  const tickRef = useRef(0);
+  const [syncCommand, setSyncCommand] = useState<TSyncCommand | undefined>(undefined);
+
+  const fire = (isOpen: boolean) => {
+    tickRef.current += 1;
+    setSyncCommand({ isOpen, key: tickRef.current });
+  };
+
+  return (
+    <ExamplePage
+      title="1. Presets — gentle / wobbly / stiff"
+      description="Three named presets. Click each card individually, or use Open all / Close all to fire them simultaneously and compare the easing characters side by side."
+    >
+      <div className={styles.toolbar}>
+        <button type="button" onClick={() => fire(true)}>
+          Open all
+        </button>
+        <button type="button" onClick={() => fire(false)}>
+          Close all
+        </button>
+      </div>
+      <div className={`${styles.grid} ${styles.grid_3}`}>
+        {PRESETS_LIST.map((preset) => (
+          <ConfigCard
+            key={preset}
+            label={`animationPreset="${preset}"`}
+            preset={preset}
+            syncCommand={syncCommand}
+          />
+        ))}
+      </div>
+    </ExamplePage>
+  );
+};
+
+export default PresetsExample;

--- a/playground/examples/TensionSpectrumExample.tsx
+++ b/playground/examples/TensionSpectrumExample.tsx
@@ -1,0 +1,24 @@
+import ExamplePage from "./shared/ExamplePage";
+import ConfigCard from "./shared/ConfigCard";
+import styles from "./shared/styles.module.css";
+
+const TENSION_VALUES = [80, 150, 220, 400];
+
+const TensionSpectrumExample = () => (
+  <ExamplePage
+    title="3. Tension spectrum"
+    description="Increasing tension at fixed mass (1) and friction (18). Higher tension means a stiffer spring — faster acceleration, sharper finish."
+  >
+    <div className={`${styles.grid} ${styles.grid_4}`}>
+      {TENSION_VALUES.map((tension) => (
+        <ConfigCard
+          key={tension}
+          label={`tension: ${tension}`}
+          config={{ mass: 1, tension, friction: 18 }}
+        />
+      ))}
+    </div>
+  </ExamplePage>
+);
+
+export default TensionSpectrumExample;

--- a/playground/examples/registry.ts
+++ b/playground/examples/registry.ts
@@ -1,0 +1,15 @@
+import { ComponentType } from "react";
+import { TView } from "../nav/Sidebar";
+import PresetsExample from "./PresetsExample";
+import MassSpectrumExample from "./MassSpectrumExample";
+import TensionSpectrumExample from "./TensionSpectrumExample";
+import FrictionSpectrumExample from "./FrictionSpectrumExample";
+import AccordionExample from "./AccordionExample";
+
+export const REGISTRY: Record<Exclude<TView, "sandbox">, ComponentType> = {
+  presets: PresetsExample,
+  mass: MassSpectrumExample,
+  tension: TensionSpectrumExample,
+  friction: FrictionSpectrumExample,
+  accordion: AccordionExample,
+};

--- a/playground/examples/shared/ConfigCard.tsx
+++ b/playground/examples/shared/ConfigCard.tsx
@@ -1,0 +1,50 @@
+import { useState, useEffect } from "react";
+import { SpringConfig } from "@react-spring/web";
+import { Collapsible, TAnimationPreset } from "../../../src";
+import { getContent, TContentLength } from "./content";
+import styles from "./styles.module.css";
+
+export type TSyncCommand = { isOpen: boolean; key: number };
+
+type Props = {
+  label: string;
+  preset?: TAnimationPreset;
+  config?: SpringConfig;
+  contentLength?: TContentLength;
+  syncCommand?: TSyncCommand;
+};
+
+const ConfigCard = ({
+  label,
+  preset,
+  config,
+  contentLength = "medium",
+  syncCommand,
+}: Props) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (syncCommand) setIsExpanded(syncCommand.isOpen);
+  }, [syncCommand]);
+
+  return (
+    <article className={styles.card}>
+      <header
+        className={styles.card_header}
+        onClick={() => setIsExpanded((p) => !p)}
+      >
+        <span>{label}</span>
+        <span>{isExpanded ? "▲" : "▼"}</span>
+      </header>
+      <Collapsible
+        isExpanded={isExpanded}
+        setIsExpanded={setIsExpanded}
+        animationPreset={preset}
+        animationHeightConfig={config}
+        content={<div className={styles.card_content}>{getContent(contentLength)}</div>}
+      />
+    </article>
+  );
+};
+
+export default ConfigCard;

--- a/playground/examples/shared/ExamplePage.tsx
+++ b/playground/examples/shared/ExamplePage.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+import styles from "./styles.module.css";
+
+type Props = {
+  title: string;
+  description: string;
+  children: ReactNode;
+};
+
+const ExamplePage = ({ title, description, children }: Props) => (
+  <section>
+    <h1>{title}</h1>
+    <p className={styles.lead}>{description}</p>
+    {children}
+  </section>
+);
+
+export default ExamplePage;

--- a/playground/examples/shared/content.ts
+++ b/playground/examples/shared/content.ts
@@ -1,0 +1,20 @@
+export type TContentLength = "short" | "medium" | "long";
+
+const SNIPPETS: Record<TContentLength, string> = {
+  short:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur.",
+  medium:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur. " +
+    "Phasellus pellentesque, lectus id sodales pretium, lacus tortor convallis nibh, eu venenatis arcu eros vitae nibh. " +
+    "Donec vitae diam et nibh sagittis suscipit a non quam. Aliquam erat volutpat.",
+  long:
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eget nisi a enim luctus efficitur. " +
+    "Phasellus pellentesque, lectus id sodales pretium, lacus tortor convallis nibh, eu venenatis arcu eros vitae nibh. " +
+    "Donec vitae diam et nibh sagittis suscipit a non quam. Aliquam erat volutpat. " +
+    "Sed ac libero in mauris pulvinar consequat. Suspendisse potenti. Nullam non purus a magna ullamcorper sodales. " +
+    "Mauris pellentesque, sapien id rutrum euismod, eros lectus dictum erat, et tincidunt erat justo nec lacus. " +
+    "Cras vitae nisl id risus aliquam pharetra. Etiam sit amet pretium tellus, in tristique tortor.",
+};
+
+export const getContent = (length: TContentLength = "medium"): string =>
+  SNIPPETS[length];

--- a/playground/examples/shared/styles.module.css
+++ b/playground/examples/shared/styles.module.css
@@ -1,0 +1,71 @@
+.lead {
+  margin: 0 0 24px;
+  color: #4a4a4a;
+  font-size: 0.95rem;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid_3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.grid_4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.grid_1 {
+  grid-template-columns: 1fr;
+}
+
+.toolbar {
+  display: flex;
+  gap: 8px;
+  margin: 0 0 16px;
+}
+
+.toolbar button {
+  padding: 8px 14px;
+  border: 1px solid #d4d4d4;
+  background: #fff;
+  border-radius: 6px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.toolbar button:hover {
+  background: #f3f3f3;
+}
+
+.card {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.card_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 0.85rem;
+  background: #f7f7f7;
+  cursor: pointer;
+  user-select: none;
+}
+
+.card_header span:last-child {
+  color: #6b6b6b;
+}
+
+.card_content {
+  padding: 12px 14px;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: #333;
+}

--- a/playground/examples/shared/styles.module.css
+++ b/playground/examples/shared/styles.module.css
@@ -7,6 +7,7 @@
 .grid {
   display: grid;
   gap: 16px;
+  align-items: start;
 }
 
 .grid_3 {

--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collapsible — Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/main.tsx"></script>
+  </body>
+</html>

--- a/playground/main.tsx
+++ b/playground/main.tsx
@@ -1,0 +1,9 @@
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./styles/global.css";
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element with id 'root' was not found");
+}
+createRoot(rootElement).render(<App />);

--- a/playground/nav/Sidebar.tsx
+++ b/playground/nav/Sidebar.tsx
@@ -1,0 +1,67 @@
+import "../styles/global.css";
+
+export type TView =
+  | "presets"
+  | "mass"
+  | "tension"
+  | "friction"
+  | "accordion"
+  | "sandbox";
+
+const NAV_ITEMS: Array<{ id: TView; label: string; group: "examples" | "interactive" }> = [
+  { id: "presets", label: "1. Presets", group: "examples" },
+  { id: "mass", label: "2. Mass spectrum", group: "examples" },
+  { id: "tension", label: "3. Tension spectrum", group: "examples" },
+  { id: "friction", label: "4. Friction spectrum", group: "examples" },
+  { id: "accordion", label: "5. FAQ accordion", group: "examples" },
+  { id: "sandbox", label: "Sandbox", group: "interactive" },
+];
+
+type Props = {
+  active: TView;
+  onChange: (view: TView) => void;
+};
+
+const Sidebar = ({ active, onChange }: Props) => {
+  const examples = NAV_ITEMS.filter((i) => i.group === "examples");
+  const interactive = NAV_ITEMS.filter((i) => i.group === "interactive");
+
+  return (
+    <aside className="app__sidebar">
+      <h2>Examples</h2>
+      <ul className="app__nav-list">
+        {examples.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={`app__nav-item${
+                active === item.id ? " app__nav-item--active" : ""
+              }`}
+              onClick={() => onChange(item.id)}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <h2 style={{ marginTop: 24 }}>Interactive</h2>
+      <ul className="app__nav-list">
+        {interactive.map((item) => (
+          <li key={item.id}>
+            <button
+              type="button"
+              className={`app__nav-item${
+                active === item.id ? " app__nav-item--active" : ""
+              }`}
+              onClick={() => onChange(item.id)}
+            >
+              {item.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+};
+
+export default Sidebar;

--- a/playground/sandbox/ControlsPanel.tsx
+++ b/playground/sandbox/ControlsPanel.tsx
@@ -1,0 +1,112 @@
+import { TAnimationPreset, PRESETS } from "../../src";
+import { TSandboxConfig } from "./types";
+import Slider from "./controls/Slider";
+import Toggle from "./controls/Toggle";
+import Select from "./controls/Select";
+import styles from "./styles.module.css";
+
+type Props = {
+  value: TSandboxConfig;
+  onChange: (next: TSandboxConfig) => void;
+};
+
+const PRESET_OPTIONS: Array<{ value: TAnimationPreset; label: string }> = [
+  { value: "gentle", label: "gentle" },
+  { value: "wobbly", label: "wobbly" },
+  { value: "stiff", label: "stiff" },
+];
+
+const ControlsPanel = ({ value, onChange }: Props) => {
+  const setHeight = (key: "mass" | "tension" | "friction", n: number) =>
+    onChange({
+      ...value,
+      heightConfig: { ...value.heightConfig, [key]: n },
+    });
+
+  const setPreset = (preset: TAnimationPreset) =>
+    onChange({
+      ...value,
+      preset,
+      heightConfig: { ...PRESETS[preset] },
+    });
+
+  return (
+    <section className={styles.panel}>
+      <h2 className={styles.panel_title}>Controls</h2>
+
+      <Select
+        label="preset"
+        value={value.preset}
+        options={PRESET_OPTIONS}
+        onChange={setPreset}
+      />
+
+      <Slider
+        label="mass"
+        min={0.1}
+        max={5}
+        step={0.1}
+        value={value.heightConfig.mass}
+        onChange={(n) => setHeight("mass", n)}
+        format={(n) => n.toFixed(1)}
+      />
+      <Slider
+        label="tension"
+        min={1}
+        max={500}
+        step={1}
+        value={value.heightConfig.tension}
+        onChange={(n) => setHeight("tension", n)}
+      />
+      <Slider
+        label="friction"
+        min={1}
+        max={100}
+        step={1}
+        value={value.heightConfig.friction}
+        onChange={(n) => setHeight("friction", n)}
+      />
+      <Slider
+        label="opacity (ms)"
+        min={0}
+        max={2000}
+        step={50}
+        value={value.opacityDuration}
+        onChange={(n) => onChange({ ...value, opacityDuration: n })}
+      />
+      <Slider
+        label="minHeight"
+        min={0}
+        max={200}
+        step={5}
+        value={value.minHeight}
+        onChange={(n) => onChange({ ...value, minHeight: n })}
+      />
+
+      <div style={{ marginTop: 12 }}>
+        <Toggle
+          label="isAnimateOpacity"
+          checked={value.isAnimateOpacity}
+          onChange={(b) => onChange({ ...value, isAnimateOpacity: b })}
+        />
+        <Toggle
+          label="isAnimateHeight"
+          checked={value.isAnimateHeight}
+          onChange={(b) => onChange({ ...value, isAnimateHeight: b })}
+        />
+        <Toggle
+          label="isOverflowHidden"
+          checked={value.isOverflowHidden}
+          onChange={(b) => onChange({ ...value, isOverflowHidden: b })}
+        />
+        <Toggle
+          label="isContentSelectable"
+          checked={value.isContentSelectable}
+          onChange={(b) => onChange({ ...value, isContentSelectable: b })}
+        />
+      </div>
+    </section>
+  );
+};
+
+export default ControlsPanel;

--- a/playground/sandbox/ProfilesPanel.tsx
+++ b/playground/sandbox/ProfilesPanel.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { TSandboxConfig, INITIAL_CONFIG } from "./types";
+import { TUseProfiles } from "./useProfiles";
+import styles from "./styles.module.css";
+
+type Props = {
+  profiles: TUseProfiles;
+  currentConfig: TSandboxConfig;
+  onLoad: (config: TSandboxConfig) => void;
+};
+
+const ProfilesPanel = ({ profiles, currentConfig, onLoad }: Props) => {
+  const [draftName, setDraftName] = useState("");
+
+  const handleSave = () => {
+    const name = draftName.trim();
+    if (!name) return;
+    if (profiles.exists(name)) {
+      const ok = window.confirm(`Profile "${name}" already exists. Overwrite?`);
+      if (!ok) return;
+    }
+    profiles.save(name, currentConfig);
+    setDraftName("");
+  };
+
+  const handleDelete = (name: string) => {
+    const ok = window.confirm(`Delete profile "${name}"?`);
+    if (ok) profiles.remove(name);
+  };
+
+  const items = profiles.list();
+
+  return (
+    <section className={styles.panel}>
+      <h2 className={styles.panel_title}>Profiles</h2>
+
+      {items.length === 0 ? (
+        <p style={{ margin: "0 0 12px", color: "#6b6b6b", fontSize: "0.85rem" }}>
+          No saved profiles yet. Tweak the controls and save them with a name.
+        </p>
+      ) : (
+        <ul className={styles.profiles_list}>
+          {items.map((name) => (
+            <li key={name} className={styles.profile_item}>
+              <span>{name}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  const cfg = profiles.load(name);
+                  if (cfg) onLoad(cfg);
+                }}
+              >
+                Load
+              </button>
+              <button type="button" onClick={() => handleDelete(name)}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className={styles.profile_actions}>
+        <input
+          type="text"
+          placeholder="Profile name"
+          value={draftName}
+          onChange={(e) => setDraftName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSave();
+          }}
+          style={{ flex: 1, padding: "6px 8px", border: "1px solid #d4d4d4", borderRadius: 4 }}
+        />
+        <button type="button" onClick={handleSave}>
+          Save as…
+        </button>
+        <button type="button" onClick={() => onLoad(INITIAL_CONFIG)}>
+          Reset
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ProfilesPanel;

--- a/playground/sandbox/Sandbox.tsx
+++ b/playground/sandbox/Sandbox.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Collapsible } from "../../src";
+import { TSandboxConfig, INITIAL_CONFIG } from "./types";
+import { useProfiles } from "./useProfiles";
+import ControlsPanel from "./ControlsPanel";
+import ProfilesPanel from "./ProfilesPanel";
+import { getContent } from "../examples/shared/content";
+import styles from "./styles.module.css";
+
+const Sandbox = () => {
+  const [config, setConfig] = useState<TSandboxConfig>(INITIAL_CONFIG);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const profiles = useProfiles();
+
+  return (
+    <section>
+      <h1>Sandbox</h1>
+      <p style={{ margin: "0 0 24px", color: "#4a4a4a", fontSize: "0.95rem" }}>
+        Live tweak every Collapsible knob and persist named profiles in localStorage.
+      </p>
+
+      <div className={styles.layout}>
+        <ControlsPanel value={config} onChange={setConfig} />
+        <ProfilesPanel
+          profiles={profiles}
+          currentConfig={config}
+          onLoad={setConfig}
+        />
+      </div>
+
+      <div className={styles.preview}>
+        <button type="button" onClick={() => setIsExpanded((p) => !p)}>
+          {isExpanded ? "Close preview" : "Open preview"}
+        </button>
+        <Collapsible
+          isExpanded={isExpanded}
+          setIsExpanded={setIsExpanded}
+          animationPreset={config.preset}
+          animationHeightConfig={config.heightConfig}
+          animationOpacityConfig={{ duration: config.opacityDuration }}
+          isAnimateOpacity={config.isAnimateOpacity}
+          isAnimateHeight={config.isAnimateHeight}
+          isOverflowHidden={config.isOverflowHidden}
+          isContentSelectable={config.isContentSelectable}
+          minHeight={config.minHeight}
+          content={
+            <div style={{ padding: 12, background: "#f7f7f7", borderRadius: 6 }}>
+              {getContent("medium")}
+            </div>
+          }
+        />
+      </div>
+
+      {!profiles.persistenceOk && (
+        <div className={styles.toast}>
+          localStorage is unavailable — profiles will not persist across reload.
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default Sandbox;

--- a/playground/sandbox/controls/Select.tsx
+++ b/playground/sandbox/controls/Select.tsx
@@ -1,0 +1,25 @@
+import styles from "../styles.module.css";
+
+type Option<T extends string> = { value: T; label: string };
+
+type Props<T extends string> = {
+  label: string;
+  value: T;
+  options: Option<T>[];
+  onChange: (value: T) => void;
+};
+
+const Select = <T extends string,>({ label, value, options, onChange }: Props<T>) => (
+  <div className={styles.select_row}>
+    <label>{label}</label>
+    <select value={value} onChange={(e) => onChange(e.target.value as T)}>
+      {options.map((o) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+export default Select;

--- a/playground/sandbox/controls/Slider.tsx
+++ b/playground/sandbox/controls/Slider.tsx
@@ -1,0 +1,28 @@
+import styles from "../styles.module.css";
+
+type Props = {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+  format?: (value: number) => string;
+};
+
+const Slider = ({ label, value, min, max, step, onChange, format }: Props) => (
+  <div className={styles.control_row}>
+    <label>{label}</label>
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+    <span className={styles.value}>{format ? format(value) : value}</span>
+  </div>
+);
+
+export default Slider;

--- a/playground/sandbox/controls/Toggle.tsx
+++ b/playground/sandbox/controls/Toggle.tsx
@@ -1,0 +1,20 @@
+import styles from "../styles.module.css";
+
+type Props = {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+const Toggle = ({ label, checked, onChange }: Props) => (
+  <label className={styles.toggle_row}>
+    <input
+      type="checkbox"
+      checked={checked}
+      onChange={(e) => onChange(e.target.checked)}
+    />
+    <span>{label}</span>
+  </label>
+);
+
+export default Toggle;

--- a/playground/sandbox/styles.module.css
+++ b/playground/sandbox/styles.module.css
@@ -1,0 +1,132 @@
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.panel {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.panel_title {
+  margin: 0 0 12px;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b6b6b;
+}
+
+.control_row {
+  display: grid;
+  grid-template-columns: 110px 1fr 60px;
+  align-items: center;
+  gap: 12px;
+  margin: 8px 0;
+}
+
+.control_row label {
+  font-size: 0.85rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.control_row input[type="range"] {
+  width: 100%;
+}
+
+.control_row .value {
+  font-size: 0.85rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  text-align: right;
+  color: #444;
+}
+
+.toggle_row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0;
+  font-size: 0.85rem;
+}
+
+.select_row {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 12px;
+  align-items: center;
+  margin: 8px 0;
+}
+
+.select_row select {
+  padding: 6px 8px;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  font: inherit;
+}
+
+.profiles_list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.profile_item {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 8px;
+  background: #f7f7f7;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.profile_item button {
+  padding: 4px 8px;
+  border: 1px solid #d4d4d4;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.8rem;
+}
+
+.profile_actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.preview {
+  margin-top: 24px;
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.preview button {
+  padding: 8px 14px;
+  border: 1px solid #d4d4d4;
+  background: #fafafa;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  margin-bottom: 12px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: #1a1a1a;
+  color: #fff;
+  padding: 10px 14px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}

--- a/playground/sandbox/types.ts
+++ b/playground/sandbox/types.ts
@@ -1,0 +1,28 @@
+import { TAnimationPreset } from "../../src";
+
+export type TSandboxConfig = {
+  preset: TAnimationPreset;
+  heightConfig: { mass: number; tension: number; friction: number };
+  opacityDuration: number;
+  isAnimateOpacity: boolean;
+  isAnimateHeight: boolean;
+  isOverflowHidden: boolean;
+  isContentSelectable: boolean;
+  minHeight: number;
+};
+
+export type TProfilesStore = {
+  schemaVersion: 1;
+  profiles: Record<string, TSandboxConfig>;
+};
+
+export const INITIAL_CONFIG: TSandboxConfig = {
+  preset: "gentle",
+  heightConfig: { mass: 1, tension: 180, friction: 18 },
+  opacityDuration: 250,
+  isAnimateOpacity: true,
+  isAnimateHeight: true,
+  isOverflowHidden: true,
+  isContentSelectable: true,
+  minHeight: 0,
+};

--- a/playground/sandbox/useProfiles.ts
+++ b/playground/sandbox/useProfiles.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TProfilesStore, TSandboxConfig } from "./types";
+
+const STORAGE_KEY = "collapsible-playground:profiles";
+const SCHEMA_VERSION = 1 as const;
+
+const emptyStore = (): TProfilesStore => ({
+  schemaVersion: SCHEMA_VERSION,
+  profiles: {},
+});
+
+const loadStore = (): { store: TProfilesStore; persistenceOk: boolean } => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { store: emptyStore(), persistenceOk: true };
+    const parsed = JSON.parse(raw) as TProfilesStore;
+    if (parsed.schemaVersion !== SCHEMA_VERSION) {
+      return { store: emptyStore(), persistenceOk: true };
+    }
+    return { store: parsed, persistenceOk: true };
+  } catch {
+    return { store: emptyStore(), persistenceOk: false };
+  }
+};
+
+const saveStore = (store: TProfilesStore): boolean => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export type TUseProfiles = {
+  list: () => string[];
+  save: (name: string, config: TSandboxConfig) => void;
+  load: (name: string) => TSandboxConfig | undefined;
+  remove: (name: string) => void;
+  exists: (name: string) => boolean;
+  persistenceOk: boolean;
+};
+
+export const useProfiles = (): TUseProfiles => {
+  const initial = useRef(loadStore());
+  const [store, setStore] = useState<TProfilesStore>(initial.current.store);
+  const [persistenceOk, setPersistenceOk] = useState(initial.current.persistenceOk);
+
+  useEffect(() => {
+    const ok = saveStore(store);
+    if (!ok) setPersistenceOk(false);
+  }, [store]);
+
+  const list = useCallback(
+    () => Object.keys(store.profiles).sort((a, b) => a.localeCompare(b)),
+    [store]
+  );
+
+  const save = useCallback(
+    (name: string, config: TSandboxConfig) => {
+      setStore((prev) => ({
+        ...prev,
+        profiles: { ...prev.profiles, [name]: config },
+      }));
+    },
+    []
+  );
+
+  const load = useCallback(
+    (name: string): TSandboxConfig | undefined => {
+      const entry = store.profiles[name];
+      return entry ? { ...entry, heightConfig: { ...entry.heightConfig } } : undefined;
+    },
+    [store]
+  );
+
+  const remove = useCallback((name: string) => {
+    setStore((prev) => {
+      const next = { ...prev.profiles };
+      delete next[name];
+      return { ...prev, profiles: next };
+    });
+  }, []);
+
+  const exists = useCallback((name: string) => name in store.profiles, [store]);
+
+  return { list, save, load, remove, exists, persistenceOk };
+};

--- a/playground/styles/global.css
+++ b/playground/styles/global.css
@@ -1,0 +1,30 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+    Arial, sans-serif;
+  color: #1a1a1a;
+  background: #fafafa;
+}
+
+a {
+  color: #0a66c2;
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-size: 1.6rem;
+}
+
+p {
+  line-height: 1.55;
+}

--- a/playground/styles/global.css
+++ b/playground/styles/global.css
@@ -28,3 +28,60 @@ h1 {
 p {
   line-height: 1.55;
 }
+
+.app__layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.app__sidebar {
+  background: #fff;
+  border-right: 1px solid #e5e5e5;
+  padding: 24px 0;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.app__sidebar h2 {
+  margin: 0 24px 16px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #6b6b6b;
+}
+
+.app__nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.app__nav-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 10px 24px;
+  font: inherit;
+  color: #1a1a1a;
+  cursor: pointer;
+}
+
+.app__nav-item:hover {
+  background: #f1f1f1;
+}
+
+.app__nav-item--active {
+  background: #1a1a1a;
+  color: #fff;
+}
+
+.app__main {
+  padding: 32px 40px 80px;
+  max-width: 960px;
+  width: 100%;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head> </head>
-  <body>
-    <div id="root"></div>
-  </body>
-</html>

--- a/src/components/Collapsible/Collapsible.tsx
+++ b/src/components/Collapsible/Collapsible.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useEffect, useRef } from "react";
-import { animated, useSpring } from "@react-spring/web";
+import { animated, useSpring, SpringConfig } from "@react-spring/web";
 import styles from "./styles.module.css";
+import { PRESETS } from "./presets";
 import { TCollapsibleProps, TContainerHeight } from "../../types/collapsible";
 import { isFunction, isUndefined } from "../../types/typeguards";
 
@@ -16,11 +17,8 @@ const Collapsible = ({
   isAccordion = false,
   isContentSelectable = true,
   minHeight,
-  animationHeightConfig = {
-    mass: 1,
-    tension: 176,
-    friction: 26,
-  },
+  animationPreset = "gentle",
+  animationHeightConfig,
   animationOpacityConfig = {
     duration: 250,
   },
@@ -30,7 +28,6 @@ const Collapsible = ({
   openedTabId,
   setOpenedTabId,
   finalHeight = "auto",
-  // callbacks
   onAnimationFinished,
 }: TCollapsibleProps) => {
   const isExpandedRef = useRef<boolean>(isExpanded);
@@ -39,13 +36,15 @@ const Collapsible = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const containerContentRef = useRef<HTMLDivElement | null>(null);
 
+  const resolvedHeightConfig: SpringConfig = {
+    ...PRESETS[animationPreset],
+    ...animationHeightConfig,
+  };
+
   const handleAnimationStart = () => {
     wrapperRef.current?.classList.add(styles.state__animate);
   };
 
-  // Keep the onRest logic in a ref so the version captured by the initial
-  // useSpring(() => ...) call always sees the latest props (isSetHeightAuto,
-  // finalHeight, onAnimationFinished) instead of the ones from mount.
   const animationRestRef = useRef<() => void>(() => {});
   animationRestRef.current = () => {
     if (isExpandedRef.current && isSetHeightAuto) {
@@ -85,7 +84,7 @@ const Collapsible = ({
       onRest: handleAnimationRest,
       config: (key: string) => {
         if (key === "height") {
-          return animationHeightConfig;
+          return resolvedHeightConfig;
         } else if (key === "opacity" && isAnimateOpacity) {
           return animationOpacityConfig;
         }
@@ -145,14 +144,12 @@ const Collapsible = ({
     height: height,
   };
 
-  // collapse other tabs if is any another tab is expanded
   useEffect(() => {
     if (isAccordion && openedTabId !== accordionTabId) {
       collapseContainer(false);
     }
   }, [openedTabId]);
 
-  // react to external isExpanded changes (skip the very first mount)
   useEffect(() => {
     if (!isMountedRef.current) {
       isMountedRef.current = true;

--- a/src/components/Collapsible/presets.ts
+++ b/src/components/Collapsible/presets.ts
@@ -1,0 +1,9 @@
+import { SpringConfig } from "@react-spring/web";
+
+export const PRESETS = {
+  gentle: { mass: 1, tension: 120, friction: 14 },
+  wobbly: { mass: 1, tension: 180, friction: 12 },
+  stiff: { mass: 1, tension: 210, friction: 20 },
+} as const satisfies Record<string, SpringConfig>;
+
+export type TAnimationPreset = keyof typeof PRESETS;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,42 +1,4 @@
-import React, { useState } from "react";
-import ReactDOM from "react-dom/client";
-import Collapsible from "./components/Collapsible/Collapsible";
-
-const App = () => {
-  const [isExpanded, setIsExpanded] = useState<boolean>(false);
-
-  const handleCollapsibleToggle = () => {
-    setIsExpanded((prevState) => !prevState);
-  };
-
-  return (
-    <>
-      <button onClick={handleCollapsibleToggle}>
-        {isExpanded ? "Close me" : "Open me"}
-      </button>
-      <Collapsible
-        isExpanded={isExpanded}
-        setIsExpanded={setIsExpanded}
-        content={
-          <article>
-            Lorem Ipsum is simply dummy text of the printing and typesetting
-            industry. Lorem Ipsum has been the industry's standard dummy text
-            ever since the 1500s, when an unknown printer took a galley of type
-            and scrambled it to make a type specimen book. It has survived not
-            only five centuries, but also the leap into electronic typesetting,
-            remaining essentially unchanged. It was popularised in the 1960s
-            with the release of Letraset sheets containing Lorem Ipsum passages,
-            and more recently with desktop publishing software like Aldus
-            PageMaker including versions of Lorem Ipsum.
-          </article>
-        }
-      />
-    </>
-  );
-};
-
-const rootElement = document.getElementById("root");
-if (!rootElement) {
-  throw new Error("Root element with id 'root' was not found");
-}
-ReactDOM.createRoot(rootElement).render(<App />);
+export { default as Collapsible } from "./components/Collapsible/Collapsible";
+export { PRESETS } from "./components/Collapsible/presets";
+export type { TAnimationPreset } from "./components/Collapsible/presets";
+export type { TCollapsibleProps } from "./types/collapsible";

--- a/src/types/collapsible.ts
+++ b/src/types/collapsible.ts
@@ -1,5 +1,6 @@
 import React, { Dispatch, SetStateAction } from "react";
-import {SpringConfig, SpringValues} from "@react-spring/web";
+import { SpringConfig, SpringValues } from "@react-spring/web";
+import { TAnimationPreset } from "../components/Collapsible/presets";
 
 export type TContainerHeight = SpringValues<{
   height: number | string;
@@ -24,6 +25,7 @@ interface ICollapsibleBaseProps {
   isAnimateHeight?: boolean;
   isSetHeightAuto?: boolean;
   isContentSelectable?: boolean;
+  animationPreset?: TAnimationPreset;
   animationHeightConfig?: SpringConfig;
   animationOpacityConfig?: SpringConfig;
   customStyles?: TCollapsibleStyles;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2023",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -13,13 +9,11 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react"
+    "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src", "playground"]
 }

--- a/tsconfig.lib.json
+++ b/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["playground"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.tsx"],
+  format: ["cjs", "esm"],
+  dts: true,
+  clean: true,
+  external: ["react", "react-dom", "@react-spring/web"],
+  tsconfig: "tsconfig.lib.json",
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  root: "playground",
+  base: "/collapsible/",
+  build: {
+    outDir: "../playground-dist",
+    emptyOutDir: true,
+  },
+  server: { port: 5173, open: true },
+});


### PR DESCRIPTION
## Summary
- 3 first-class animation presets on \`<Collapsible />\` (`gentle` / `wobbly` / `stiff`, default `gentle`); explicit \`animationHeightConfig\` overrides per-key.
- Vite-based playground in \`playground/\` with sidebar nav, 5 example pages (Presets / Mass / Tension / Friction / FAQ accordion) and an interactive sandbox with named profiles persisted to \`localStorage\`.
- GitHub Actions workflow auto-deploys the playground to GitHub Pages on push to \`main\`.
- v1 → v2.0.0 major bump: lib entry cleaned to exports-only (fixes a v1 bug where importing the package executed \`ReactDOM.createRoot\`); default config changes from \`{tension:176, friction:26}\` to \`gentle\`. Migration snippet in README.

## Spec & plan
- \`docs/superpowers/specs/2026-05-02-collapsible-examples-design.md\`
- \`docs/superpowers/plans/2026-05-02-collapsible-examples.md\`

## Test plan
- [ ] \`npm install\` clean
- [ ] \`npm run lint\` passes
- [ ] \`npm run build\` produces \`dist/index.{js,mjs,d.ts,d.mts}\` with no \`createRoot\` calls
- [ ] \`npm run playground:build\` produces \`playground-dist/index.html\` referencing \`/collapsible/assets/...\`
- [ ] \`npm run dev\` boots Vite at \`http://localhost:5173/collapsible/\`
- [ ] All 5 example pages render; presets show distinct easing characters
- [ ] Sandbox: tension slider re-springs preview live
- [ ] Sandbox: profile saved to localStorage survives page reload, loads back into controls
- [ ] After merge: \`Settings → Pages → Source: GitHub Actions\`, then workflow deploys to \`https://kolosochek.github.io/collapsible/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)